### PR TITLE
IDA 9.4 迁移: CMake 构建 / API 适配 / 编码整理 / HEXRAYS API 版本可配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# build output
+build/
+*.aps
+
+# user-specific IDE state
+*.vcxproj.user
+.vs/

--- a/E-Decompiler/CMakeLists.txt
+++ b/E-Decompiler/CMakeLists.txt
@@ -1,0 +1,71 @@
+# E-Decompiler — IDA 9.4 插件构建
+# 用法 (BuildTools 自带 CMake):
+#   "D:\Aiagent tool\VS2022BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -S . -B build
+#   cmake --build build --config Release
+cmake_minimum_required(VERSION 3.25)
+
+set(IDASDK "D:/Aiagent tool/ida-sdk/src" CACHE PATH "IDA SDK root (git clone: HexRaysSA/ida-sdk)")
+include("${IDASDK}/cmake/idasdk_standalone.cmake")
+project(EDecompiler CXX)
+set(CMAKE_CXX_STANDARD 17)
+include("${IDASDK}/cmake/idasdk_init.cmake")
+find_package(idasdk REQUIRED)
+
+# hexrays API 版本须与装机引擎匹配: 9.4.0 正式版 = 5 (默认); 早期 9.4 build(如 260610) = 4
+set(EDEC_HEXRAYS_API_VERSION "5" CACHE STRING "hexrays API version: 5 = 9.4.0 release, 4 = earlier 9.4 builds")
+
+# 注: ControlInfoWidget(.cpp/.h/.ui)/PropertyDelegate 是 7.5 时代的 Qt 属性查看窗口,
+# 与其余模块零耦合, 9.4 版暂不参与构建 (SDK 不带 Qt6 头文件, 需另装 Qt6 才能启用)。
+ida_add_plugin(E-Decompiler
+    SOURCES
+        EDecompiler.cpp
+        ESymbol.cpp
+        ECSigParser.cpp
+        ImportsParser.cpp
+        SectionManager.cpp
+        TrieTree.cpp
+        EAppControl/EAppControl.cpp
+        EAppControl/EAppControlFactory.cpp
+        EAppControl/CKrnl_window.cpp
+        EAppControl/CKrnl_AnimateBox.cpp
+        EAppControl/CKrnl_Button.cpp
+        EAppControl/CKrnl_CheckBox.cpp
+        EAppControl/CKrnl_ChkListBox.cpp
+        EAppControl/CKrnl_ComboBox.cpp
+        EAppControl/CKrnl_DrawPanel.cpp
+        EAppControl/CKrnl_DropTarget.cpp
+        EAppControl/CKrnl_EditBox.cpp
+        EAppControl/CKrnl_GroupBox.cpp
+        EAppControl/CKrnl_HScrollBar.cpp
+        EAppControl/CKrnl_Label.cpp
+        EAppControl/CKrnl_ListBox.cpp
+        EAppControl/CKrnl_PicBox.cpp
+        EAppControl/CKrnl_PicBtn.cpp
+        EAppControl/CKrnl_ProcessBar.cpp
+        EAppControl/CKrnl_RadioBox.cpp
+        EAppControl/CKrnl_ShapeBox.cpp
+        EAppControl/CKrnl_SliderBar.cpp
+        EAppControl/CKrnl_Tab.cpp
+        EAppControl/CKrnl_Timer.cpp
+        EAppControl/CKrnl_VScrollBar.cpp
+        EAppControl/CIext2_CartoonBox.cpp
+        EAppControl/CIext2_IPEditBox.cpp
+        EAppControl/CIext2_RichEdit.cpp
+        EAppControl/CIext2_SplitterBar.cpp
+        EAppControl/CIext2_SuperAnimateBox.cpp
+        EAppControl/CIext2_SuperBtn.cpp
+        Module/CTreeFixer.cpp
+        Module/EAppControlXref.cpp
+        Module/ECSigMaker.cpp
+        Module/ECSigScanner.cpp
+        Module/MicroCodeFixer.cpp
+        Module/ShowEventList.cpp
+        Module/ShowImports.cpp
+        Utils/Common.cpp
+        Utils/IDAMenu.cpp
+        Utils/IDAWrapper.cpp
+        Utils/Strings.cpp
+        Utils/md5.cpp
+)
+
+target_compile_definitions(E-Decompiler PRIVATE EDEC_HEXRAYS_API_VERSION=${EDEC_HEXRAYS_API_VERSION})

--- a/E-Decompiler/ControlInfoWidget.cpp
+++ b/E-Decompiler/ControlInfoWidget.cpp
@@ -1,4 +1,4 @@
-#include "ControlInfoWidget.h"
+ï»¿#include "ControlInfoWidget.h"
 
 #include <bytes.hpp>
 #include "PropertyDelegate.h"
@@ -10,9 +10,9 @@
 
 QString Control_GetBoolStr(unsigned int value)
 {
-	QString ret = QStringLiteral("Õæ");
+	QString ret = QStringLiteral("çœŸ");
 	if (!value) {
-		ret = QStringLiteral("¼Ù");
+		ret = QStringLiteral("å‡");
 	}
 	return ret;
 }
@@ -25,7 +25,7 @@ ControlInfoWidget::ControlInfoWidget()
 	ui.ControlTable->setSelectionMode(QAbstractItemView::SingleSelection);
 	ui.ControlTable->setSelectionBehavior(QAbstractItemView::SelectItems);
 	ui.ControlTable->setItemDelegate(new PropertyDelegate(ui.ControlTable));
-	ui.ControlTable->setColumnWidth(1, 200);   //ÉèÖÃµÚ¶şÁĞ¿í¶È
+	ui.ControlTable->setColumnWidth(1, 200);   //è®¾ç½®ç¬¬äºŒåˆ—å®½åº¦
 
 	connect(ui.treeWidget, &QTreeWidget::itemClicked, this, [&](QTreeWidgetItem* item, int column) {
 		on_controlClicked(item, column);
@@ -44,8 +44,8 @@ void ControlInfoWidget::on_controlClicked(QTreeWidgetItem* item, int column)
 
 	QTreeWidgetItem* parentItem = item->parent();
 	if (!item->parent()) {
-		//µã»÷µÄÊÇ×îÉÏ²ã½Úµã
-		ui.groupBox->setTitle(QStringLiteral("´°¿Ú"));
+		//ç‚¹å‡»çš„æ˜¯æœ€ä¸Šå±‚èŠ‚ç‚¹
+		ui.groupBox->setTitle(QStringLiteral("çª—å£"));
 	}
 	else {
 		unsigned int controlId = item->data(0, Qt::UserRole).toUInt();
@@ -54,7 +54,7 @@ void ControlInfoWidget::on_controlClicked(QTreeWidgetItem* item, int column)
 		//if (GuiParser::GetControlInfo(controlId, currentControl)) {
 		//	ui.groupBox->setTitle(QString::fromLocal8Bit(currentControl.m_controlTypeName.c_str()));
 			//eSymbol_ControlType controlType = GuiParser::GetControlType(currentControl.m_controlTypeId);
-			//EAppControl::ÏÔÊ¾¿Ø¼şĞÅÏ¢(controlType, currentControl.m_propertyAddr, currentControl.m_propertySize);
+			//EAppControl::æ˜¾ç¤ºæ§ä»¶ä¿¡æ¯(controlType, currentControl.m_propertyAddr, currentControl.m_propertySize);
 		//}
 	}
 

--- a/E-Decompiler/ControlInfoWidget.h
+++ b/E-Decompiler/ControlInfoWidget.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <QtWidgets/QtWidgets>
 #include "ui_ControlInfoWidget.h"
 

--- a/E-Decompiler/EAppControl/CIext2_CartoonBox.cpp
+++ b/E-Decompiler/EAppControl/CIext2_CartoonBox.cpp
@@ -1,4 +1,4 @@
-#include "CIext2_CartoonBox.h"
+ï»¿#include "CIext2_CartoonBox.h"
 
 CIext2_CartoonBox::CIext2_CartoonBox()
 {
@@ -15,41 +15,41 @@ std::string CIext2_CartoonBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "ÎïÌå×ó¼ü±»°´ÏÂ";
+		return "ç‰©ä½“å·¦é”®è¢«æŒ‰ä¸‹";
 	case 1:
-		return "ÎïÌåÓÒ¼ü±»°´ÏÂ";
+		return "ç‰©ä½“å³é”®è¢«æŒ‰ä¸‹";
 	case 2:
-		return "ÎïÌå×ó¼ü±»·Å¿ª";
+		return "ç‰©ä½“å·¦é”®è¢«æ”¾å¼€";
 	case 3:
-		return "ÎïÌåÓÒ¼ü±»·Å¿ª";
+		return "ç‰©ä½“å³é”®è¢«æ”¾å¼€";
 	case 4:
-		return "Ë«»÷ÎïÌå";
+		return "åŒå‡»ç‰©ä½“";
 	case 5:
-		return "½øÈëÎïÌå";
+		return "è¿›å…¥ç‰©ä½“";
 	case 6:
-		return "Àë¿ªÎïÌå";
+		return "ç¦»å¼€ç‰©ä½“";
 	case 7:
-		return "¶¯»­¿òÊó±êÎ»ÖÃ¸Ä±ä";
+		return "åŠ¨ç”»æ¡†é¼ æ ‡ä½ç½®æ”¹å˜";
 	case 8:
-		return "ÎïÌåÎ»ÖÃ½«¸Ä±ä";
+		return "ç‰©ä½“ä½ç½®å°†æ”¹å˜";
 	case 9:
-		return "ÎïÌåÎ»ÖÃÒÑ¸Ä±ä";
+		return "ç‰©ä½“ä½ç½®å·²æ”¹å˜";
 	case 10:
-		return "ÎïÌå½«Ïú»Ù";
+		return "ç‰©ä½“å°†é”€æ¯";
 	case 11:
-		return "Åö×²µ½ÎïÌå";
+		return "ç¢°æ’åˆ°ç‰©ä½“";
 	case 12:
-		return "Åö×²µ½±ß½ç";
+		return "ç¢°æ’åˆ°è¾¹ç•Œ";
 	case 13:
-		return "Ô½³ö±ß½ç";
+		return "è¶Šå‡ºè¾¹ç•Œ";
 	case 14:
-		return "×Ô¶¯Ç°½øÍ£Ö¹";
+		return "è‡ªåŠ¨å‰è¿›åœæ­¢";
 	case 15:
-		return "×Ô¶¯Ğı×ªÍ£Ö¹";
+		return "è‡ªåŠ¨æ—‹è½¬åœæ­¢";
 	case 16:
-		return "¶¯»­²¥·ÅÍê±Ï";
+		return "åŠ¨ç”»æ’­æ”¾å®Œæ¯•";
 	case 17:
-		return "¼àÊÓ¼ü±»°´ÏÂ";
+		return "ç›‘è§†é”®è¢«æŒ‰ä¸‹";
 	default:
 		break;
 	}
@@ -66,48 +66,48 @@ std::string CIext2_CartoonBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 10:
-		return "±³¾°Í¼Æ¬";
+		return "èƒŒæ™¯å›¾ç‰‡";
 	case 11:
-		return "ÏÔÊ¾·½Ê½";
+		return "æ˜¾ç¤ºæ–¹å¼";
 	case 12:
-		return "»­±ÊÀàĞÍ";
+		return "ç”»ç¬”ç±»å‹";
 	case 13:
-		return "»­³ö·½Ê½";
+		return "ç”»å‡ºæ–¹å¼";
 	case 14:
-		return "»­±Ê´ÖÏ¸";
+		return "ç”»ç¬”ç²—ç»†";
 	case 15:
-		return "»­±ÊÑÕÉ«";
+		return "ç”»ç¬”é¢œè‰²";
 	case 16:
-		return "Ë¢×ÓÀàĞÍ";
+		return "åˆ·å­ç±»å‹";
 	case 17:
-		return "Ë¢×ÓÑÕÉ«";
+		return "åˆ·å­é¢œè‰²";
 	case 18:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 19:
-		return "ÎÄ±¾±³¾°ÑÕÉ«";
+		return "æ–‡æœ¬èƒŒæ™¯é¢œè‰²";
 	case 20:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }
 

--- a/E-Decompiler/EAppControl/CIext2_CartoonBox.h
+++ b/E-Decompiler/EAppControl/CIext2_CartoonBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//¶¯»­¿ò
+//åŠ¨ç”»æ¡†
 
 struct CIext2_CartoonBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CIext2_IPEditBox.cpp
+++ b/E-Decompiler/EAppControl/CIext2_IPEditBox.cpp
@@ -1,4 +1,4 @@
-#include "CIext2_IPEditBox.h"
+ï»¿#include "CIext2_IPEditBox.h"
 
 CIext2_IPEditBox::CIext2_IPEditBox()
 {
@@ -15,7 +15,7 @@ std::string CIext2_IPEditBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "µØÖ·±»¸Ä±ä";
+		return "åœ°å€è¢«æ”¹å˜";
 	default:
 		break;
 	}
@@ -32,26 +32,26 @@ std::string CIext2_IPEditBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 9:
-		return "µØÖ·";
+		return "åœ°å€";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }
 

--- a/E-Decompiler/EAppControl/CIext2_IPEditBox.h
+++ b/E-Decompiler/EAppControl/CIext2_IPEditBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//IP±à¼­¿ò
+//IPç¼–è¾‘æ¡†
 
 struct CIext2_IPEditBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CIext2_RichEdit.cpp
+++ b/E-Decompiler/EAppControl/CIext2_RichEdit.cpp
@@ -1,4 +1,4 @@
-#include "CIext2_RichEdit.h"
+ï»¿#include "CIext2_RichEdit.h"
 
 CIext2_RichEdit::CIext2_RichEdit()
 {
@@ -15,9 +15,9 @@ std::string CIext2_RichEdit::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "ÄÚÈİ±»¸Ä±ä";
+		return "å†…å®¹è¢«æ”¹å˜";
 	case 1:
-		return "Ñ¡ÔñÇø±»¸Ä±ä";
+		return "é€‰æ‹©åŒºè¢«æ”¹å˜";
 	default:
 		break;
 	}
@@ -34,48 +34,48 @@ std::string CIext2_RichEdit::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "ÄÚÈİ¸ñÊ½";
+		return "å†…å®¹æ ¼å¼";
 	case 9:
-		return "ÄÚÈİ";
+		return "å†…å®¹";
 	case 10:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 11:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 12:
-		return "ÊÇ·ñÔÊĞí¶àĞĞ";
+		return "æ˜¯å¦å…è®¸å¤šè¡Œ";
 	case 13:
-		return "×Ô¶¯»»ĞĞ";
+		return "è‡ªåŠ¨æ¢è¡Œ";
 	case 14:
-		return "Ö»¶Á";
+		return "åªè¯»";
 	case 15:
-		return "Òş²ØÑ¡Ôñ";
+		return "éšè—é€‰æ‹©";
 	case 16:
-		return "×î´óÔÊĞí³¤¶È";
+		return "æœ€å¤§å…è®¸é•¿åº¦";
 	case 17:
-		return "ÆğÊ¼Ñ¡ÔñÎ»ÖÃ";
+		return "èµ·å§‹é€‰æ‹©ä½ç½®";
 	case 18:
-		return "±»Ñ¡Ôñ×Ö·ûÊı";
+		return "è¢«é€‰æ‹©å­—ç¬¦æ•°";
 	case 19:
-		return "±»Ñ¡ÔñÎÄ±¾";
+		return "è¢«é€‰æ‹©æ–‡æœ¬";
 	case 20:
-		return "ÊÇ·ñÒÑ¸ü¸Ä";
+		return "æ˜¯å¦å·²æ›´æ”¹";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }
 

--- a/E-Decompiler/EAppControl/CIext2_RichEdit.h
+++ b/E-Decompiler/EAppControl/CIext2_RichEdit.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//³¬¼¶±à¼­¿ò
+//è¶…çº§ç¼–è¾‘æ¡†
 
 struct CIext2_RichEdit :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CIext2_SplitterBar.cpp
+++ b/E-Decompiler/EAppControl/CIext2_SplitterBar.cpp
@@ -1,4 +1,4 @@
-#include "CIext2_SplitterBar.h"
+ï»¿#include "CIext2_SplitterBar.h"
 
 CIext2_SplitterBar::CIext2_SplitterBar()
 {
@@ -15,7 +15,7 @@ std::string CIext2_SplitterBar::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "±»ÍÏ¶¯";
+		return "è¢«æ‹–åŠ¨";
 	default:
 		break;
 	}
@@ -32,26 +32,26 @@ std::string CIext2_SplitterBar::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 9:
-		return "·½Ïò";
+		return "æ–¹å‘";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }
 

--- a/E-Decompiler/EAppControl/CIext2_SplitterBar.h
+++ b/E-Decompiler/EAppControl/CIext2_SplitterBar.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//·Ö¸ôÌõ
+//åˆ†éš”æ¡
 
 struct CIext2_SplitterBar :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CIext2_SuperAnimateBox.cpp
+++ b/E-Decompiler/EAppControl/CIext2_SuperAnimateBox.cpp
@@ -1,4 +1,4 @@
-#include "CIext2_SuperAnimateBox.h"
+ï»¿#include "CIext2_SuperAnimateBox.h"
 
 CIext2_SuperAnimateBox::CIext2_SuperAnimateBox()
 {
@@ -25,40 +25,40 @@ std::string CIext2_SuperAnimateBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "²¥·ÅÎ»ÖÃ";
+		return "æ’­æ”¾ä½ç½®";
 	case 9:
-		return "Ó°ÏñÎÄ¼şÃû";
+		return "å½±åƒæ–‡ä»¶å";
 	case 10:
-		return "²¥·ÅËÙ¶È";
+		return "æ’­æ”¾é€Ÿåº¦";
 	case 11:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 12:
-		return "Í¸Ã÷ÑÕÉ«";
+		return "é€æ˜é¢œè‰²";
 	case 13:
-		return "²¥·Å";
+		return "æ’­æ”¾";
 	case 14:
-		return "½ö²¥·ÅÒ»´Î";
+		return "ä»…æ’­æ”¾ä¸€æ¬¡";
 	case 15:
-		return "µ±Ç°Ö¡";
+		return "å½“å‰å¸§";
 	case 16:
-		return "È«²¿Ö¡Êı";
+		return "å…¨éƒ¨å¸§æ•°";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }
 

--- a/E-Decompiler/EAppControl/CIext2_SuperAnimateBox.h
+++ b/E-Decompiler/EAppControl/CIext2_SuperAnimateBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//¸ß¼¶Ó°Ïñ¿ò
+//é«˜çº§å½±åƒæ¡†
 
 struct CIext2_SuperAnimateBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CIext2_SuperBtn.cpp
+++ b/E-Decompiler/EAppControl/CIext2_SuperBtn.cpp
@@ -1,4 +1,4 @@
-#include "CIext2_SuperBtn.h"
+ï»¿#include "CIext2_SuperBtn.h"
 
 CIext2_SuperBtn::CIext2_SuperBtn()
 {
@@ -15,7 +15,7 @@ std::string CIext2_SuperBtn::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "±»µ¥»÷";
+		return "è¢«å•å‡»";
 	default:
 		break;
 	}
@@ -32,76 +32,76 @@ std::string CIext2_SuperBtn::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "°´Å¥·ç¸ñ";
+		return "æŒ‰é’®é£æ ¼";
 	case 9:
-		return "Ñ¡Ôñ¿ò·½Ê½";
+		return "é€‰æ‹©æ¡†æ–¹å¼";
 	case 10:
-		return "Ñ¡ÖĞ";
+		return "é€‰ä¸­";
 	case 11:
-		return "¶ÔÆë·½Ê½";
+		return "å¯¹é½æ–¹å¼";
 	case 12:
-		return "Ñ¹Èë·½Ê½";
+		return "å‹å…¥æ–¹å¼";
 	case 13:
-		return "»æÖÆ±ß¿ò";
+		return "ç»˜åˆ¶è¾¹æ¡†";
 	case 14:
-		return "»æÖÆ½¹µã";
+		return "ç»˜åˆ¶ç„¦ç‚¹";
 	case 15:
-		return "Í¨³£Í¼Æ¬";
+		return "é€šå¸¸å›¾ç‰‡";
 	case 16:
-		return "Í¨³£Í¼Æ¬Í¸Ã÷É«";
+		return "é€šå¸¸å›¾ç‰‡é€æ˜è‰²";
 	case 17:
-		return "µãÈ¼Í¼Æ¬";
+		return "ç‚¹ç‡ƒå›¾ç‰‡";
 	case 18:
-		return "µãÈ¼Í¼Æ¬Í¸Ã÷É«";
+		return "ç‚¹ç‡ƒå›¾ç‰‡é€æ˜è‰²";
 	case 19:
-		return "½ûÖ¹Í¼Æ¬";
+		return "ç¦æ­¢å›¾ç‰‡";
 	case 20:
-		return "½ûÖ¹Í¼Æ¬Í¸Ã÷É«";
+		return "ç¦æ­¢å›¾ç‰‡é€æ˜è‰²";
 	case 21:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 22:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 23:
-		return "Ê¹ÓÃÄ¬ÈÏÉ«";
+		return "ä½¿ç”¨é»˜è®¤è‰²";
 	case 24:
-		return "Í¨³£Ç°¾°É«";
+		return "é€šå¸¸å‰æ™¯è‰²";
 	case 25:
-		return "Í¨³£±³¾°É«";
+		return "é€šå¸¸èƒŒæ™¯è‰²";
 	case 26:
-		return "µãÈ¼Ç°¾°É«";
+		return "ç‚¹ç‡ƒå‰æ™¯è‰²";
 	case 27:
-		return "µãÈ¼±³¾°É«";
+		return "ç‚¹ç‡ƒèƒŒæ™¯è‰²";
 	case 28:
-		return "½¹µãÇ°¾°É«";
+		return "ç„¦ç‚¹å‰æ™¯è‰²";
 	case 29:
-		return "½¹µã±³¾°É«";
+		return "ç„¦ç‚¹èƒŒæ™¯è‰²";
 	case 30:
-		return "±ê×¼ÒôÌáÊ¾";
+		return "æ ‡å‡†éŸ³æç¤º";
 	case 31:
-		return "¾­¹ıÌáÊ¾Òô";
+		return "ç»è¿‡æç¤ºéŸ³";
 	case 32:
-		return "µ¥»÷ÌáÊ¾Òô";
+		return "å•å‡»æç¤ºéŸ³";
 	case 33:
-		return "ÌáÊ¾ÎÄ±¾";
+		return "æç¤ºæ–‡æœ¬";
 	case 34:
-		return "Ä¬ÈÏÀàĞÍ";
+		return "é»˜è®¤ç±»å‹";
 	}
-	return "Î´ÖªÊÂ¼ş";
+	return "æœªçŸ¥äº‹ä»¶";
 }
 

--- a/E-Decompiler/EAppControl/CIext2_SuperBtn.h
+++ b/E-Decompiler/EAppControl/CIext2_SuperBtn.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//³¬¼¶°´Å¥
+//è¶…çº§æŒ‰é’®
 
 struct CIext2_SuperBtn :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_AnimateBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_AnimateBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_AnimateBox.h"
+ï»¿#include "CKrnl_AnimateBox.h"
 
 CKrnl_AnimateBox::CKrnl_AnimateBox()
 {
@@ -25,31 +25,31 @@ std::string CKrnl_AnimateBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "ÎÄ¼şÃû";
+		return "æ–‡ä»¶å";
 	case 9:
-		return "¾ÓÖĞ²¥·Å";
+		return "å±…ä¸­æ’­æ”¾";
 	case 10:
-		return "Í¸Ã÷±³¾°";
+		return "é€æ˜èƒŒæ™¯";
 	case 11:
-		return "²¥·Å";
+		return "æ’­æ”¾";
 	case 12:
-		return "²¥·Å´ÎÊı";
+		return "æ’­æ”¾æ¬¡æ•°";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_AnimateBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_AnimateBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//Ó°Ïñ¿ò
+//å½±åƒæ¡†
 
 struct CKrnl_AnimateBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_Button.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_Button.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_Button.h"
+ï»¿#include "CKrnl_Button.h"
 
 CKrnl_Button::CKrnl_Button()
 {
@@ -15,7 +15,7 @@ std::string CKrnl_Button::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "±»µ¥»÷";
+		return "è¢«å•å‡»";
 	default:
 		break;
 	}
@@ -32,33 +32,33 @@ std::string CKrnl_Button::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "Í¼Æ¬";
+		return "å›¾ç‰‡";
 	case 9:
-		return "ÀàĞÍ";
+		return "ç±»å‹";
 	case 10:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 11:
-		return "ºáÏò¶ÔÆë·½Ê½";
+		return "æ¨ªå‘å¯¹é½æ–¹å¼";
 	case 12:
-		return "×İÏò¶ÔÆë·½Ê½";
+		return "çºµå‘å¯¹é½æ–¹å¼";
 	case 13:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_Button.h
+++ b/E-Decompiler/EAppControl/CKrnl_Button.h
@@ -1,7 +1,7 @@
-#pragma once
+﻿#pragma once
 #include "EAppControl.h"
 
-//��ť
+//按钮
 
 struct CKrnl_Button :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_CheckBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_CheckBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_CheckBox.h"
+ï»¿#include "CKrnl_CheckBox.h"
 
 CKrnl_CheckBox::CKrnl_CheckBox()
 {
@@ -15,7 +15,7 @@ std::string CKrnl_CheckBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "±»µ¥»÷";
+		return "è¢«å•å‡»";
 	default:
 		break;
 	}
@@ -32,47 +32,47 @@ std::string CKrnl_CheckBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "Í¼Æ¬";
+		return "å›¾ç‰‡";
 	case 9:
-		return "°´Å¥ĞÎÊ½";
+		return "æŒ‰é’®å½¢å¼";
 	case 10:
-		return "Æ½Ãæ";
+		return "å¹³é¢";
 	case 11:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 12:
-		return "±êÌâ¾Ó×ó";
+		return "æ ‡é¢˜å±…å·¦";
 	case 13:
-		return "ºáÏò¶ÔÆë·½Ê½";
+		return "æ¨ªå‘å¯¹é½æ–¹å¼";
 	case 14:
-		return "×İÏò¶ÔÆë·½Ê½";
+		return "çºµå‘å¯¹é½æ–¹å¼";
 	case 15:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 16:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 17:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 18:
-		return "Ñ¡ÖĞ";
+		return "é€‰ä¸­";
 	case 19:
-		return "Êı¾İÔ´";
+		return "æ•°æ®æº";
 	case 20:
-		return "Êı¾İÁĞ";
+		return "æ•°æ®åˆ—";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_CheckBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_CheckBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//Ñ¡Ôñ¿ò
+//é€‰æ‹©æ¡†
 
 struct CKrnl_CheckBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_ChkListBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_ChkListBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_ChkListBox.h"
+ï»¿#include "CKrnl_ChkListBox.h"
 
 
 CKrnl_ChkListBox::CKrnl_ChkListBox()
@@ -17,51 +17,51 @@ std::string CKrnl_ChkListBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		ret = "ÁĞ±íÏî±»Ñ¡Ôñ";
+		ret = "åˆ—è¡¨é¡¹è¢«é€‰æ‹©";
 		break;
 	case 1:
-		ret = "Ñ¡ÖĞ×´Ì¬±»¸Ä±ä";
+		ret = "é€‰ä¸­çŠ¶æ€è¢«æ”¹å˜";
 		break;
 	case 2:
-		ret = "Ë«»÷Ñ¡Ôñ";
+		ret = "åŒå‡»é€‰æ‹©";
 		break;
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -7:
-		ret = "»ñµÃ½¹µã";
+		ret = "è·å¾—ç„¦ç‚¹";
 		break;
 	case -8:
-		ret = "Ê§È¥½¹µã";
+		ret = "å¤±å»ç„¦ç‚¹";
 		break;
 	case -9:
-		ret = "°´ÏÂÄ³¼ü";
+		ret = "æŒ‰ä¸‹æŸé”®";
 		break;
 	case -10:
-		ret = "·Å¿ªÄ³¼ü";
+		ret = "æ”¾å¼€æŸé”®";
 		break;
 	case -11:
-		ret = "×Ö·ûÊäÈë";
+		ret = "å­—ç¬¦è¾“å…¥";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 
@@ -78,39 +78,39 @@ std::string CKrnl_ChkListBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "×Ô¶¯ÅÅĞò";
+		return "è‡ªåŠ¨æ’åº";
 	case 10:
-		return "¶àÁĞ";
+		return "å¤šåˆ—";
 	case 11:
-		return "ĞĞ¼ä¾à";
+		return "è¡Œé—´è·";
 	case 12:
-		return "µ¥Ñ¡";
+		return "å•é€‰";
 	case 13:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 14:
-		return "ÏÖĞĞÑ¡ÖĞÏî";
+		return "ç°è¡Œé€‰ä¸­é¡¹";
 	case 15:
-		return "ÁĞ±íÏîÄ¿";
+		return "åˆ—è¡¨é¡¹ç›®";
 	case 16:
-		return "ÏîÄ¿ÊıÖµ";
+		return "é¡¹ç›®æ•°å€¼";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_ChkListBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_ChkListBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//Ñ¡ÔñÁÐ±í¿ò
+//é€‰æ‹©åˆ—è¡¨æ¡†
 
 struct CKrnl_ChkListBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_ComboBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_ComboBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_ComboBox.h"
+ï»¿#include "CKrnl_ComboBox.h"
 
 CKrnl_ComboBox::CKrnl_ComboBox()
 {
@@ -15,15 +15,15 @@ std::string CKrnl_ComboBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "ÁĞ±íÏî±»Ñ¡Ôñ";
+		return "åˆ—è¡¨é¡¹è¢«é€‰æ‹©";
 	case 1:
-		return "±à¼­ÄÚÈİ±»¸Ä±ä";
+		return "ç¼–è¾‘å†…å®¹è¢«æ”¹å˜";
 	case 2:
-		return "½«µ¯³öÁĞ±í";
+		return "å°†å¼¹å‡ºåˆ—è¡¨";
 	case 3:
-		return "ÁĞ±í±»¹Ø±Õ";
+		return "åˆ—è¡¨è¢«å…³é—­";
 	case 4:
-		return "Ë«»÷Ñ¡Ôñ";
+		return "åŒå‡»é€‰æ‹©";
 	default:
 		break;
 	}
@@ -40,55 +40,55 @@ std::string CKrnl_ComboBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "ÀàĞÍ";
+		return "ç±»å‹";
 	case 9:
-		return "ÄÚÈİ";
+		return "å†…å®¹";
 	case 10:
-		return "×î´óÎÄ±¾³¤¶È";
+		return "æœ€å¤§æ–‡æœ¬é•¿åº¦";
 	case 11:
-		return "ÆğÊ¼Ñ¡ÔñÎ»ÖÃ";
+		return "èµ·å§‹é€‰æ‹©ä½ç½®";
 	case 12:
-		return "±»Ñ¡Ôñ×Ö·ûÊı";
+		return "è¢«é€‰æ‹©å­—ç¬¦æ•°";
 	case 13:
-		return "±»Ñ¡ÔñÎÄ±¾";
+		return "è¢«é€‰æ‹©æ–‡æœ¬";
 	case 14:
-		return "×Ô¶¯ÅÅĞò";
+		return "è‡ªåŠ¨æ’åº";
 	case 15:
-		return "ĞĞ¼ä¾à";
+		return "è¡Œé—´è·";
 	case 16:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 17:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 18:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 19:
-		return "ÏÖĞĞÑ¡ÖĞÏî";
+		return "ç°è¡Œé€‰ä¸­é¡¹";
 	case 20:
-		return "ÁĞ±íÏîÄ¿";
+		return "åˆ—è¡¨é¡¹ç›®";
 	case 21:
-		return "ÏîÄ¿ÊıÖµ";
+		return "é¡¹ç›®æ•°å€¼";
 	case 22:
-		return "Êı¾İÔ´";
+		return "æ•°æ®æº";
 	case 23:
-		return "Êı¾İÁĞ";
+		return "æ•°æ®åˆ—";
 	case 24:
-		return "³ıÈ¥ÖØ¸´";
+		return "é™¤å»é‡å¤";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_ComboBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_ComboBox.h
@@ -1,8 +1,8 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
 
-//×éºÏ¿ò
+//ç»„åˆæ¡†
 
 struct CKrnl_ComboBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_DrawPanel.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_DrawPanel.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_DrawPanel.h"
+ï»¿#include "CKrnl_DrawPanel.h"
 
 CKrnl_DrawPanel::CKrnl_DrawPanel()
 {
@@ -15,7 +15,7 @@ std::string CKrnl_DrawPanel::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "»æ»­";
+		return "ç»˜ç”»";
 	default:
 		break;
 	}
@@ -32,55 +32,55 @@ std::string CKrnl_DrawPanel::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "»­°å±³¾°É«";
+		return "ç”»æ¿èƒŒæ™¯è‰²";
 	case 10:
-		return "µ×Í¼";
+		return "åº•å›¾";
 	case 11:
-		return "µ×Í¼·½Ê½";
+		return "åº•å›¾æ–¹å¼";
 	case 12:
-		return "×Ô¶¯ÖØ»­";
+		return "è‡ªåŠ¨é‡ç”»";
 	case 13:
-		return "»æ»­µ¥Î»";
+		return "ç»˜ç”»å•ä½";
 	case 14:
-		return "»­±ÊÀàĞÍ";
+		return "ç”»ç¬”ç±»å‹";
 	case 15:
-		return "»­³ö·½Ê½";
+		return "ç”»å‡ºæ–¹å¼";
 	case 16:
-		return "»­±Ê´ÖÏ¸";
+		return "ç”»ç¬”ç²—ç»†";
 	case 17:
-		return "»­±ÊÑÕÉ«";
+		return "ç”»ç¬”é¢œè‰²";
 	case 18:
-		return "Ë¢×ÓÀàĞÍ";
+		return "åˆ·å­ç±»å‹";
 	case 19:
-		return "Ë¢×ÓÑÕÉ«";
+		return "åˆ·å­é¢œè‰²";
 	case 20:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 21:
-		return "ÎÄ±¾±³¾°ÑÕÉ«";
+		return "æ–‡æœ¬èƒŒæ™¯é¢œè‰²";
 	case 22:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 23:
-		return "»­°å¿í¶È";
+		return "ç”»æ¿å®½åº¦";
 	case 24:
-		return "»­°å¸ß¶È";
+		return "ç”»æ¿é«˜åº¦";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_DrawPanel.h
+++ b/E-Decompiler/EAppControl/CKrnl_DrawPanel.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//»­°å
+//ç”»æ¿
 
 struct CKrnl_DrawPanel :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_DropTarget.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_DropTarget.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_DropTarget.h"
+ï»¿#include "CKrnl_DropTarget.h"
 
 
 CKrnl_DropTarget::CKrnl_DropTarget()
@@ -17,19 +17,19 @@ std::string CKrnl_DropTarget::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		ret = "µÃµ½ÎÄ±¾";
+		ret = "å¾—åˆ°æ–‡æœ¬";
 		break;
 	case 1:
-		ret = "µÃµ½³¬ÎÄ±¾";
+		ret = "å¾—åˆ°è¶…æ–‡æœ¬";
 		break;
 	case 2:
-		ret = "µÃµ½URL";
+		ret = "å¾—åˆ°URL";
 		break;
 	case 3:
-		ret = "µÃµ½ÎÄ¼þ";
+		ret = "å¾—åˆ°æ–‡ä»¶";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼þ";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 
@@ -43,5 +43,5 @@ bool CKrnl_DropTarget::InitControlExtraData(unsigned int propertyAddr, unsigned 
 
 std::string CKrnl_DropTarget::GetPropertyName(unsigned int propertyIndex)
 {
-	return "Î´ÖªÊôÐÔ";
+	return "æœªçŸ¥å±žæ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_DropTarget.h
+++ b/E-Decompiler/EAppControl/CKrnl_DropTarget.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//ÍÏ·Å¶ÔÏó
+//æ‹–æ”¾å¯¹è±¡
 
 struct CKrnl_DropTarget :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_EditBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_EditBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_EditBox.h"
+ï»¿#include "CKrnl_EditBox.h"
 
 CKrnl_EditBox::CKrnl_EditBox()
 {
@@ -15,9 +15,9 @@ std::string CKrnl_EditBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "ÄÚÈİ±»¸Ä±ä";
+		return "å†…å®¹è¢«æ”¹å˜";
 	case 1:
-		return "µ÷½ÚÅ¥±»°´ÏÂ";
+		return "è°ƒèŠ‚é’®è¢«æŒ‰ä¸‹";
 	default:
 		break;
 	}
@@ -34,63 +34,63 @@ std::string CKrnl_EditBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "ÄÚÈİ";
+		return "å†…å®¹";
 	case 9:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 10:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 11:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 12:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 13:
-		return "Òş²ØÑ¡Ôñ";
+		return "éšè—é€‰æ‹©";
 	case 14:
-		return "×î´óÔÊĞí³¤¶È";
+		return "æœ€å¤§å…è®¸é•¿åº¦";
 	case 15:
-		return "ÊÇ·ñÔÊĞí¶àĞĞ";
+		return "æ˜¯å¦å…è®¸å¤šè¡Œ";
 	case 16:
-		return "¹ö¶¯Ìõ";
+		return "æ»šåŠ¨æ¡";
 	case 17:
-		return "¶ÔÆë·½Ê½";
+		return "å¯¹é½æ–¹å¼";
 	case 18:
-		return "ÊäÈë·½Ê½";
+		return "è¾“å…¥æ–¹å¼";
 	case 19:
-		return "ÃÜÂëÕÚ¸Ç×Ö·û";
+		return "å¯†ç é®ç›–å­—ç¬¦";
 	case 20:
-		return "×ª»»·½Ê½";
+		return "è½¬æ¢æ–¹å¼";
 	case 21:
-		return "µ÷½ÚÆ÷·½Ê½";
+		return "è°ƒèŠ‚å™¨æ–¹å¼";
 	case 22:
-		return "µ÷½ÚÆ÷µ×ÏŞÖµ";
+		return "è°ƒèŠ‚å™¨åº•é™å€¼";
 	case 23:
-		return "µ÷½ÚÆ÷ÉÏÏŞÖµ";
+		return "è°ƒèŠ‚å™¨ä¸Šé™å€¼";
 	case 24:
-		return "ÆğÊ¼Ñ¡ÔñÎ»ÖÃ";
+		return "èµ·å§‹é€‰æ‹©ä½ç½®";
 	case 25:
-		return "±»Ñ¡Ôñ×Ö·ûÊı";
+		return "è¢«é€‰æ‹©å­—ç¬¦æ•°";
 	case 26:
-		return "±»Ñ¡ÔñÎÄ±¾";
+		return "è¢«é€‰æ‹©æ–‡æœ¬";
 	case 27:
-		return "Êı¾İÔ´";
+		return "æ•°æ®æº";
 	case 28:
-		return "Êı¾İÁĞ";
+		return "æ•°æ®åˆ—";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_EditBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_EditBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//±à¼­¿ò
+//ç¼–è¾‘æ¡†
 
 struct CKrnl_EditBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_GroupBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_GroupBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_GroupBox.h"
+ï»¿#include "CKrnl_GroupBox.h"
 
 CKrnl_GroupBox::CKrnl_GroupBox()
 {
@@ -25,31 +25,31 @@ std::string CKrnl_GroupBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 9:
-		return "¶ÔÆë·½Ê½";
+		return "å¯¹é½æ–¹å¼";
 	case 10:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 11:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 12:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_GroupBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_GroupBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//·Ö×é¿ò
+//åˆ†ç»„æ¡†
 
 struct CKrnl_GroupBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_HScrollBar.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_HScrollBar.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_HScrollBar.h"
+ï»¿#include "CKrnl_HScrollBar.h"
 
 
 CKrnl_HScrollBar::CKrnl_HScrollBar()
@@ -16,7 +16,7 @@ std::string CKrnl_HScrollBar::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "Î»ÖÃ±»¸Ä±ä";
+		return "ä½ç½®è¢«æ”¹å˜";
 	default:
 		break;
 	}
@@ -33,33 +33,33 @@ std::string CKrnl_HScrollBar::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "×îĞ¡Î»ÖÃ";
+		return "æœ€å°ä½ç½®";
 	case 9:
-		return "×î´óÎ»ÖÃ";
+		return "æœ€å¤§ä½ç½®";
 	case 10:
-		return "Ò³¸Ä±äÖµ";
+		return "é¡µæ”¹å˜å€¼";
 	case 11:
-		return "ĞĞ¸Ä±äÖµ";
+		return "è¡Œæ”¹å˜å€¼";
 	case 12:
-		return "Î»ÖÃ";
+		return "ä½ç½®";
 	case 13:
-		return "ÔÊĞíÍÏ¶¯¸ú×Ù";
+		return "å…è®¸æ‹–åŠ¨è·Ÿè¸ª";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_HScrollBar.h
+++ b/E-Decompiler/EAppControl/CKrnl_HScrollBar.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//ºáÏò¹ö¶¯Ìõ
+//æ¨ªå‘æ»šåŠ¨æ¡
 
 struct CKrnl_HScrollBar :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_Label.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_Label.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_Label.h"
+ï»¿#include "CKrnl_Label.h"
 
 
 CKrnl_Label::CKrnl_Label()
@@ -17,31 +17,31 @@ std::string CKrnl_Label::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		ret = "·´À¡ÊÂ¼ş";
+		ret = "åé¦ˆäº‹ä»¶";
 		break;
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 	return ret;
@@ -57,63 +57,63 @@ std::string CKrnl_Label::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 9:
-		return "Ğ§¹û";
+		return "æ•ˆæœ";
 	case 10:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 11:
-		return "½¥±ä±ß¿ò¿í¶È";
+		return "æ¸å˜è¾¹æ¡†å®½åº¦";
 	case 12:
-		return "½¥±ä±ß¿òÑÕÉ«1";
+		return "æ¸å˜è¾¹æ¡†é¢œè‰²1";
 	case 13:
-		return "½¥±ä±ß¿òÑÕÉ«2";
+		return "æ¸å˜è¾¹æ¡†é¢œè‰²2";
 	case 14:
-		return "½¥±ä±ß¿òÑÕÉ«3";
+		return "æ¸å˜è¾¹æ¡†é¢œè‰²3";
 	case 15:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 16:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 17:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 18:
-		return "µ×Í¼";
+		return "åº•å›¾";
 	case 19:
-		return "µ×Í¼·½Ê½";
+		return "åº•å›¾æ–¹å¼";
 	case 20:
-		return "½¥±ä±³¾°·½Ê½";
+		return "æ¸å˜èƒŒæ™¯æ–¹å¼";
 	case 21:
-		return "½¥±ä±³¾°ÑÕÉ«1";
+		return "æ¸å˜èƒŒæ™¯é¢œè‰²1";
 	case 22:
-		return "½¥±ä±³¾°ÑÕÉ«2";
+		return "æ¸å˜èƒŒæ™¯é¢œè‰²2";
 	case 23:
-		return "½¥±ä±³¾°ÑÕÉ«3";
+		return "æ¸å˜èƒŒæ™¯é¢œè‰²3";
 	case 24:
-		return "ºáÏò¶ÔÆë·½Ê½";
+		return "æ¨ªå‘å¯¹é½æ–¹å¼";
 	case 25:
-		return "ÊÇ·ñ×Ô¶¯ÕÛĞĞ";
+		return "æ˜¯å¦è‡ªåŠ¨æŠ˜è¡Œ";
 	case 26:
-		return "×İÏò¶ÔÆë·½Ê½";
+		return "çºµå‘å¯¹é½æ–¹å¼";
 	case 27:
-		return "Êı¾İÔ´";
+		return "æ•°æ®æº";
 	case 28:
-		return "Êı¾İÁĞ";
+		return "æ•°æ®åˆ—";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_Label.h
+++ b/E-Decompiler/EAppControl/CKrnl_Label.h
@@ -1,7 +1,7 @@
-#pragma once
+﻿#pragma once
 #include "EAppControl.h"
 
-//��ǩ
+//标签
 
 struct CKrnl_Label :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_ListBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_ListBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_ListBox.h"
+ï»¿#include "CKrnl_ListBox.h"
 
 CKrnl_ListBox::CKrnl_ListBox()
 {
@@ -17,9 +17,9 @@ std::string CKrnl_ListBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "ÁĞ±í¿ò±»Ñ¡Ôñ";
+		return "åˆ—è¡¨æ¡†è¢«é€‰æ‹©";
 	case 1:
-		return "Ë«»÷Ñ¡Ôñ";
+		return "åŒå‡»é€‰æ‹©";
 	default:
 		break;
 	}
@@ -36,49 +36,49 @@ std::string CKrnl_ListBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "×Ô¶¯ÅÅĞò";
+		return "è‡ªåŠ¨æ’åº";
 	case 10:
-		return "¶àÁĞ";
+		return "å¤šåˆ—";
 	case 11:
-		return "ĞĞ¼ä¾à";
+		return "è¡Œé—´è·";
 	case 12:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 13:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 14:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 15:
-		return "ÔÊĞíÑ¡Ôñ¶àÏî";
+		return "å…è®¸é€‰æ‹©å¤šé¡¹";
 	case 16:
-		return "ÏÖĞĞÑ¡ÖĞÏî";
+		return "ç°è¡Œé€‰ä¸­é¡¹";
 	case 17:
-		return "ÁĞ±íÏîÄ¿";
+		return "åˆ—è¡¨é¡¹ç›®";
 	case 18:
-		return "ÏîÄ¿ÊıÖµ";
+		return "é¡¹ç›®æ•°å€¼";
 	case 19:
-		return "Êı¾İÔ´";
+		return "æ•°æ®æº";
 	case 20:
-		return "Êı¾İÁĞ";
+		return "æ•°æ®åˆ—";
 	case 21:
-		return "³ıÈ¥ÖØ¸´";
+		return "é™¤å»é‡å¤";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_ListBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_ListBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//ÁÐ±í¿ò
+//åˆ—è¡¨æ¡†
 
 struct CKrnl_ListBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_PicBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_PicBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_PicBox.h"
+ï»¿#include "CKrnl_PicBox.h"
 
 CKrnl_PicBox::CKrnl_PicBox()
 {
@@ -16,28 +16,28 @@ std::string CKrnl_PicBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 
@@ -54,35 +54,35 @@ std::string CKrnl_PicBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 10:
-		return "Í¼Æ¬";
+		return "å›¾ç‰‡";
 	case 11:
-		return "ÏÔÊ¾·½Ê½";
+		return "æ˜¾ç¤ºæ–¹å¼";
 	case 12:
-		return "²¥·Å¶¯»­";
+		return "æ’­æ”¾åŠ¨ç”»";
 	case 13:
-		return "Êı¾İÔ´";
+		return "æ•°æ®æº";
 	case 14:
-		return "Êı¾İÁĞ";
+		return "æ•°æ®åˆ—";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_PicBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_PicBox.h
@@ -1,7 +1,7 @@
-#pragma once
+﻿#pragma once
 #include "EAppControl.h"
 
-//ͼƬ��
+//图片框
 
 
 struct CKrnl_PicBox :public EAppControl

--- a/E-Decompiler/EAppControl/CKrnl_PicBtn.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_PicBtn.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_PicBtn.h"
+ï»¿#include "CKrnl_PicBtn.h"
 
 CKrnl_PicBtn::CKrnl_PicBtn()
 {
@@ -16,31 +16,31 @@ std::string CKrnl_PicBtn::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		ret = "±»µ¥»÷";
+		ret = "è¢«å•å‡»";
 		break;
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 	return ret;
@@ -56,35 +56,35 @@ std::string CKrnl_PicBtn::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "ÀàĞÍ";
+		return "ç±»å‹";
 	case 9:
-		return "Ñ¡ÖĞ";
+		return "é€‰ä¸­";
 	case 10:
-		return "Õı³£Í¼Æ¬";
+		return "æ­£å¸¸å›¾ç‰‡";
 	case 11:
-		return "µãÈ¼Í¼Æ¬";
+		return "ç‚¹ç‡ƒå›¾ç‰‡";
 	case 12:
-		return "°´ÏÂÍ¼Æ¬";
+		return "æŒ‰ä¸‹å›¾ç‰‡";
 	case 13:
-		return "½ûÖ¹Í¼Æ¬";
+		return "ç¦æ­¢å›¾ç‰‡";
 	case 14:
-		return "Í¸Ã÷ÑÕÉ«";
+		return "é€æ˜é¢œè‰²";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_PicBtn.h
+++ b/E-Decompiler/EAppControl/CKrnl_PicBtn.h
@@ -1,8 +1,8 @@
-#pragma once
+﻿#pragma once
 #include "EAppControl.h"
 
 
-//ͼ�ΰ�ť
+//图形按钮
 
 struct CKrnl_PicBtn :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_ProcessBar.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_ProcessBar.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_ProcessBar.h"
+ï»¿#include "CKrnl_ProcessBar.h"
 
 CKrnl_ProcessBar::CKrnl_ProcessBar()
 {
@@ -16,28 +16,28 @@ std::string CKrnl_ProcessBar::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 
@@ -54,33 +54,33 @@ std::string CKrnl_ProcessBar::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "·½Ïò";
+		return "æ–¹å‘";
 	case 10:
-		return "ÏÔÊ¾·½Ê½";
+		return "æ˜¾ç¤ºæ–¹å¼";
 	case 11:
-		return "×îĞ¡Î»ÖÃ";
+		return "æœ€å°ä½ç½®";
 	case 12:
-		return "×î´óÎ»ÖÃ";
+		return "æœ€å¤§ä½ç½®";
 	case 13:
-		return "Î»ÖÃ";
+		return "ä½ç½®";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_ProcessBar.h
+++ b/E-Decompiler/EAppControl/CKrnl_ProcessBar.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//½ø¶ÈÌõ
+//è¿›åº¦æ¡
 
 struct CKrnl_ProcessBar :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_RadioBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_RadioBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_RadioBox.h"
+ï»¿#include "CKrnl_RadioBox.h"
 
 CKrnl_RadioBox::CKrnl_RadioBox()
 {
@@ -15,7 +15,7 @@ std::string CKrnl_RadioBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "±»µ¥»÷";
+		return "è¢«å•å‡»";
 	default:
 		break;
 	}
@@ -32,43 +32,43 @@ std::string CKrnl_RadioBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "Í¼Æ¬";
+		return "å›¾ç‰‡";
 	case 9:
-		return "°´Å¥ĞÎÊ½";
+		return "æŒ‰é’®å½¢å¼";
 	case 10:
-		return "Æ½Ãæ";
+		return "å¹³é¢";
 	case 11:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 12:
-		return "±êÌâ¾Ó×ó";
+		return "æ ‡é¢˜å±…å·¦";
 	case 13:
-		return "ºáÏò¶ÔÆë·½Ê½";
+		return "æ¨ªå‘å¯¹é½æ–¹å¼";
 	case 14:
-		return "×İÏò¶ÔÆë·½Ê½";
+		return "çºµå‘å¯¹é½æ–¹å¼";
 	case 15:
-		return "ÎÄ±¾ÑÕÉ«";
+		return "æ–‡æœ¬é¢œè‰²";
 	case 16:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 17:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 18:
-		return "Ñ¡ÖĞ";
+		return "é€‰ä¸­";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_RadioBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_RadioBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//µ¥Ñ¡¿ò
+//å•é€‰æ¡†
 
 struct CKrnl_RadioBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_ShapeBox.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_ShapeBox.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_ShapeBox.h"
+ï»¿#include "CKrnl_ShapeBox.h"
 
 CKrnl_ShapeBox::CKrnl_ShapeBox()
 {
@@ -16,28 +16,28 @@ std::string CKrnl_ShapeBox::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 
@@ -54,35 +54,35 @@ std::string CKrnl_ShapeBox::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	case 9:
-		return "ÍâĞÎ";
+		return "å¤–å½¢";
 	case 10:
-		return "ÏßÌõĞ§¹û";
+		return "çº¿æ¡æ•ˆæœ";
 	case 11:
-		return "ÏßĞÍ";
+		return "çº¿å‹";
 	case 12:
-		return "Ïß¿í";
+		return "çº¿å®½";
 	case 13:
-		return "ÏßÌõÑÕÉ«";
+		return "çº¿æ¡é¢œè‰²";
 	case 14:
-		return "Ìî³äÑÕÉ«";
+		return "å¡«å……é¢œè‰²";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_ShapeBox.h
+++ b/E-Decompiler/EAppControl/CKrnl_ShapeBox.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//ÍâÐÎ¿ò
+//å¤–å½¢æ¡†
 
 struct CKrnl_ShapeBox :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_SliderBar.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_SliderBar.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_SliderBar.h"
+ï»¿#include "CKrnl_SliderBar.h"
 
 
 CKrnl_SliderBar::CKrnl_SliderBar()
@@ -16,31 +16,31 @@ std::string CKrnl_SliderBar::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "´´½¨Íê±Ï";
+		return "åˆ›å»ºå®Œæ¯•";
 	case 1:
-		return "¿É·ñ±»¹Ø±Õ";
+		return "å¯å¦è¢«å…³é—­";
 	case 2:
-		return "½«±»Ïú»Ù";
+		return "å°†è¢«é”€æ¯";
 	case 3:
-		return "Î»ÖÃ±»¸Ä±ä";
+		return "ä½ç½®è¢«æ”¹å˜";
 	case 4:
-		return "³ß´ç±»¸Ä±ä";
+		return "å°ºå¯¸è¢«æ”¹å˜";
 	case 5:
-		return "±»¼¤»î";
+		return "è¢«æ¿€æ´»";
 	case 6:
-		return "±»È¡Ïû¼¤»î";
+		return "è¢«å–æ¶ˆæ¿€æ´»";
 	case 7:
-		return "¿ÕÏĞ";
+		return "ç©ºé—²";
 	case 8:
-		return "Ê×´Î¼¤»î";
+		return "é¦–æ¬¡æ¿€æ´»";
 	case 9:
-		return "ÍĞÅÌÊÂ¼ş";
+		return "æ‰˜ç›˜äº‹ä»¶";
 	case 10:
-		return "±»ÏÔÊ¾";
+		return "è¢«æ˜¾ç¤º";
 	case 11:
-		return "±»Òş²Ø";
+		return "è¢«éšè—";
 	case 12:
-		return "´°¿Ú¿É·ñ±»¹Ø±Õ";
+		return "çª—å£å¯å¦è¢«å…³é—­";
 	default:
 		break;
 	}
@@ -57,45 +57,45 @@ std::string CKrnl_SliderBar::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 9:
-		return "·½Ïò";
+		return "æ–¹å‘";
 	case 10:
-		return "¿Ì¶ÈÀàĞÍ";
+		return "åˆ»åº¦ç±»å‹";
 	case 11:
-		return "µ¥Î»¿Ì¶ÈÖµ";
+		return "å•ä½åˆ»åº¦å€¼";
 	case 12:
-		return "ÔÊĞíÑ¡Ôñ";
+		return "å…è®¸é€‰æ‹©";
 	case 13:
-		return "Ê×Ñ¡ÔñÎ»ÖÃ";
+		return "é¦–é€‰æ‹©ä½ç½®";
 	case 14:
-		return "Ñ¡Ôñ³¤¶È";
+		return "é€‰æ‹©é•¿åº¦";
 	case 15:
-		return "Ò³¸Ä±äÖµ";
+		return "é¡µæ”¹å˜å€¼";
 	case 16:
-		return "ĞĞ¸Ä±äÖµ";
+		return "è¡Œæ”¹å˜å€¼";
 	case 17:
-		return "×îĞ¡Î»ÖÃ";
+		return "æœ€å°ä½ç½®";
 	case 18:
-		return "×î´óÎ»ÖÃ";
+		return "æœ€å¤§ä½ç½®";
 	case 19:
-		return "Î»ÖÃ";
+		return "ä½ç½®";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_SliderBar.h
+++ b/E-Decompiler/EAppControl/CKrnl_SliderBar.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//»¬¿éÌõ
+//æ»‘å—æ¡
 
 struct CKrnl_SliderBar :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_Tab.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_Tab.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_Tab.h"
+ï»¿#include "CKrnl_Tab.h"
 
 
 CKrnl_Tab::CKrnl_Tab()
@@ -17,37 +17,37 @@ std::string CKrnl_Tab::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		ret = "±»µ¥»÷";
+		ret = "è¢«å•å‡»";
 		break;
 	case 1:
-		ret = "½«¸Ä±ä×Ó¼Ğ";
+		ret = "å°†æ”¹å˜å­å¤¹";
 		break;
 	case 2:
-		ret = "×Ó¼Ğ±»¸Ä±ä";
+		ret = "å­å¤¹è¢«æ”¹å˜";
 		break;
 	case -1:
-		ret = "Êó±ê×ó¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -2:
-		ret = "Êó±ê×ó¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 		break;
 	case -3:
-		ret = "±»Ë«»÷";
+		ret = "è¢«åŒå‡»";
 		break;
 	case -4:
-		ret = "Êó±êÓÒ¼ü±»°´ÏÂ";
+		ret = "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 		break;
 	case -5:
-		ret = "Êó±êÓÒ¼ü±»·Å¿ª";
+		ret = "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 		break;
 	case -6:
-		ret = "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		ret = "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 		break;
 	case -12:
-		ret = "¹öÂÖ±»¹ö¶¯";
+		ret = "æ»šè½®è¢«æ»šåŠ¨";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 	return ret;
@@ -63,37 +63,37 @@ std::string CKrnl_Tab::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±íÍ··½Ïò";
+		return "è¡¨å¤´æ–¹å‘";
 	case 9:
-		return "ÔÊĞí¶àĞĞ±íÍ·";
+		return "å…è®¸å¤šè¡Œè¡¨å¤´";
 	case 10:
-		return "×ÖÌå";
+		return "å­—ä½“";
 	case 11:
-		return "×Ó¼Ğ¹ÜÀí";
+		return "å­å¤¹ç®¡ç†";
 	case 12:
-		return "ÏÖĞĞ×Ó¼Ğ";
+		return "ç°è¡Œå­å¤¹";
 	case 13:
-		return "Òş²Ø×ÔÉí";
+		return "éšè—è‡ªèº«";
 	case 14:
-		return "ÊÇ·ñÌî³ä±³¾°";
+		return "æ˜¯å¦å¡«å……èƒŒæ™¯";
 	case 15:
-		return "±³¾°ÑÕÉ«";
+		return "èƒŒæ™¯é¢œè‰²";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_Tab.h
+++ b/E-Decompiler/EAppControl/CKrnl_Tab.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//Ñ¡Ôñ¼Ð
+//é€‰æ‹©å¤¹
 
 
 struct CKrnl_Tab :public EAppControl

--- a/E-Decompiler/EAppControl/CKrnl_Timer.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_Timer.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_Timer.h"
+ï»¿#include "CKrnl_Timer.h"
 
 
 CKrnl_Timer::CKrnl_Timer()
@@ -17,10 +17,10 @@ std::string CKrnl_Timer::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		ret = "ÖÜÆÚÊÂ¼ş";
+		ret = "å‘¨æœŸäº‹ä»¶";
 		break;
 	default:
-		ret = "Î´ÖªÊÂ¼ş";
+		ret = "æœªçŸ¥äº‹ä»¶";
 		break;
 	}
 	return ret;
@@ -36,23 +36,23 @@ std::string CKrnl_Timer::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "Ê±ÖÓÖÜÆÚ";
+		return "æ—¶é’Ÿå‘¨æœŸ";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_Timer.h
+++ b/E-Decompiler/EAppControl/CKrnl_Timer.h
@@ -1,7 +1,7 @@
-#pragma once
+﻿#pragma once
 #include "EAppControl.h"
 
-//ʱ��
+//时钟
 
 struct CKrnl_Timer :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_VScrollBar.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_VScrollBar.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_VScrollBar.h"
+ï»¿#include "CKrnl_VScrollBar.h"
 
 CKrnl_VScrollBar::CKrnl_VScrollBar()
 {
@@ -15,7 +15,7 @@ std::string CKrnl_VScrollBar::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "Î»ÖÃ±»¸Ä±ä";
+		return "ä½ç½®è¢«æ”¹å˜";
 	default:
 		break;
 	}
@@ -32,33 +32,33 @@ std::string CKrnl_VScrollBar::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "×îĞ¡Î»ÖÃ";
+		return "æœ€å°ä½ç½®";
 	case 9:
-		return "×î´óÎ»ÖÃ";
+		return "æœ€å¤§ä½ç½®";
 	case 10:
-		return "Ò³¸Ä±äÖµ";
+		return "é¡µæ”¹å˜å€¼";
 	case 11:
-		return "ĞĞ¸Ä±äÖµ";
+		return "è¡Œæ”¹å˜å€¼";
 	case 12:
-		return "Î»ÖÃ";
+		return "ä½ç½®";
 	case 13:
-		return "ÔÊĞíÍÏ¶¯¸ú×Ù";
+		return "å…è®¸æ‹–åŠ¨è·Ÿè¸ª";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_VScrollBar.h
+++ b/E-Decompiler/EAppControl/CKrnl_VScrollBar.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//×İÏò¹ö¶¯Ìõ
+//çºµå‘æ»šåŠ¨æ¡
 
 struct CKrnl_VScrollBar :public EAppControl
 {

--- a/E-Decompiler/EAppControl/CKrnl_window.cpp
+++ b/E-Decompiler/EAppControl/CKrnl_window.cpp
@@ -1,4 +1,4 @@
-#include "CKrnl_window.h"
+ï»¿#include "CKrnl_window.h"
 
 
 CKrnl_window::CKrnl_window()
@@ -16,31 +16,31 @@ std::string CKrnl_window::GetEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case 0:
-		return "´´½¨Íê±Ï";
+		return "åˆ›å»ºå®Œæ¯•";
 	case 1:
-		return "¿É·ñ±»¹Ø±Õ";
+		return "å¯å¦è¢«å…³é—­";
 	case 2:
-		return "½«±»Ïú»Ù";
+		return "å°†è¢«é”€æ¯";
 	case 3:
-		return "Î»ÖÃ±»¸Ä±ä";
+		return "ä½ç½®è¢«æ”¹å˜";
 	case 4:
-		return "³ß´ç±»¸Ä±ä";
+		return "å°ºå¯¸è¢«æ”¹å˜";
 	case 5:
-		return "±»¼¤»î";
+		return "è¢«æ¿€æ´»";
 	case 6:
-		return "±»È¡Ïû¼¤»î";
+		return "è¢«å–æ¶ˆæ¿€æ´»";
 	case 7:
-		return "¿ÕÏĞ";
+		return "ç©ºé—²";
 	case 8:
-		return "Ê×´Î¼¤»î";
+		return "é¦–æ¬¡æ¿€æ´»";
 	case 9:
-		return "ÍĞÅÌÊÂ¼ş";
+		return "æ‰˜ç›˜äº‹ä»¶";
 	case 10:
-		return "±»ÏÔÊ¾";
+		return "è¢«æ˜¾ç¤º";
 	case 11:
-		return "±»Òş²Ø";
+		return "è¢«éšè—";
 	case 12:
-		return "´°¿Ú¿É·ñ±»¹Ø±Õ";
+		return "çª—å£å¯å¦è¢«å…³é—­";
 	default:
 		break;
 	}
@@ -59,69 +59,69 @@ std::string CKrnl_window::GetPropertyName(unsigned int propertyIndex)
 	switch (propertyIndex)
 	{
 	case 0:
-		return "×ó±ß";
+		return "å·¦è¾¹";
 	case 1:
-		return "¶¥±ß";
+		return "é¡¶è¾¹";
 	case 2:
-		return "¿í¶È";
+		return "å®½åº¦";
 	case 3:
-		return "¸ß¶È";
+		return "é«˜åº¦";
 	case 4:
-		return "±ê¼Ç";
+		return "æ ‡è®°";
 	case 5:
-		return "¿ÉÊÓ";
+		return "å¯è§†";
 	case 6:
-		return "½ûÖ¹";
+		return "ç¦æ­¢";
 	case 7:
-		return "Êó±êÖ¸Õë";
+		return "é¼ æ ‡æŒ‡é’ˆ";
 	case 8:
-		return "±êÌâ";
+		return "æ ‡é¢˜";
 	case 9:
-		return "±ß¿ò";
+		return "è¾¹æ¡†";
 	case 10:
-		return "µ×É«";
+		return "åº•è‰²";
 	case 11:
-		return "µ×Í¼";
+		return "åº•å›¾";
 	case 12:
-		return "µ×Í¼·½Ê½";
+		return "åº•å›¾æ–¹å¼";
 	case 13:
-		return "±³¾°ÒôÀÖ";
+		return "èƒŒæ™¯éŸ³ä¹";
 	case 14:
-		return "²¥·Å´ÎÊı";
+		return "æ’­æ”¾æ¬¡æ•°";
 	case 15:
-		return "¿ØÖÆ°´Å¥";
+		return "æ§åˆ¶æŒ‰é’®";
 	case 16:
-		return "×î´ó»¯°´Å¥";
+		return "æœ€å¤§åŒ–æŒ‰é’®";
 	case 17:
-		return "×îĞ¡»¯°´Å¥";
+		return "æœ€å°åŒ–æŒ‰é’®";
 	case 18:
-		return "Î»ÖÃ";
+		return "ä½ç½®";
 	case 19:
-		return "¿É·ñÒÆ¶¯";
+		return "å¯å¦ç§»åŠ¨";
 	case 20:
-		return "Í¼±ê";
+		return "å›¾æ ‡";
 	case 21:
-		return "»Ø³µÏÂÒÆ½¹µã";
+		return "å›è½¦ä¸‹ç§»ç„¦ç‚¹";
 	case 22:
-		return "Esc¼ü¹Ø±Õ";
+		return "Escé”®å…³é—­";
 	case 23:
-		return "F1¼ü´ò¿ª°ïÖú";
+		return "F1é”®æ‰“å¼€å¸®åŠ©";
 	case 24:
-		return "°ïÖúÎÄ¼şÃû";
+		return "å¸®åŠ©æ–‡ä»¶å";
 	case 25:
-		return "°ïÖú±êÖ¾Öµ";
+		return "å¸®åŠ©æ ‡å¿—å€¼";
 	case 26:
-		return "ÔÚÈÎÎñÌõÖĞÏÔÊ¾";
+		return "åœ¨ä»»åŠ¡æ¡ä¸­æ˜¾ç¤º";
 	case 27:
-		return "ËæÒâÒÆ¶¯";
+		return "éšæ„ç§»åŠ¨";
 	case 28:
-		return "ÍâĞÎ";
+		return "å¤–å½¢";
 	case 29:
-		return "×ÜÔÚ×îÇ°";
+		return "æ€»åœ¨æœ€å‰";
 	case 30:
-		return "±£³Ö±êÌâÌõ¼¤»î";
+		return "ä¿æŒæ ‡é¢˜æ¡æ¿€æ´»";
 	case 31:
-		return "´°¿ÚÀàĞÍ";
+		return "çª—å£ç±»å‹";
 	}
-	return "Î´ÖªÊôĞÔ";
+	return "æœªçŸ¥å±æ€§";
 }

--- a/E-Decompiler/EAppControl/CKrnl_window.h
+++ b/E-Decompiler/EAppControl/CKrnl_window.h
@@ -1,7 +1,7 @@
-#pragma once
+ï»¿#pragma once
 #include "EAppControl.h"
 
-//´°¿Ú
+//çª—å£
 
 struct CKrnl_window :public EAppControl
 {

--- a/E-Decompiler/EAppControl/EAppControl.cpp
+++ b/E-Decompiler/EAppControl/EAppControl.cpp
@@ -1,4 +1,4 @@
-#include "EAppControl.h"
+ï»¿#include "EAppControl.h"
 
 bool EAppControl::InitControlExtraData(unsigned int propertyAddr, unsigned int propertySize)
 {
@@ -10,30 +10,30 @@ std::string EAppControl::GetCommonEventName(int eventIndex)
 	switch (eventIndex)
 	{
 	case -1:
-		return "Êó±ê×ó¼ü±»°´ÏÂ";
+		return "é¼ æ ‡å·¦é”®è¢«æŒ‰ä¸‹";
 	case -2:
-		return "Êó±ê×ó¼ü±»·Å¿ª";
+		return "é¼ æ ‡å·¦é”®è¢«æ”¾å¼€";
 	case -3:
-		return "±»Ë«»÷";
+		return "è¢«åŒå‡»";
 	case -4:
-		return "Êó±êÓÒ¼ü±»°´ÏÂ";
+		return "é¼ æ ‡å³é”®è¢«æŒ‰ä¸‹";
 	case -5:
-		return "Êó±êÓÒ¼ü±»·Å¿ª";
+		return "é¼ æ ‡å³é”®è¢«æ”¾å¼€";
 	case -6:
-		return "Êó±êÎ»ÖÃ±»ÒÆ¶¯";
+		return "é¼ æ ‡ä½ç½®è¢«ç§»åŠ¨";
 	case -7:
-		return "»ñµÃ½¹µã";
+		return "è·å¾—ç„¦ç‚¹";
 	case -8:
-		return "Ê§È¥½¹µã";
+		return "å¤±å»ç„¦ç‚¹";
 	case -9:
-		return "°´ÏÂÄ³¼ü";
+		return "æŒ‰ä¸‹æŸé”®";
 	case -10:
-		return "·Å¿ªÄ³¼ü";
+		return "æ”¾å¼€æŸé”®";
 	case -11:
-		return "×Ö·ûÊäÈë";
+		return "å­—ç¬¦è¾“å…¥";
 	case -12:
-		return "¹öÂÖ±»¹ö¶¯";
+		return "æ»šè½®è¢«æ»šåŠ¨";
 	}
-	return "Î´ÖªÊÂ¼ş";
+	return "æœªçŸ¥äº‹ä»¶";
 
 }

--- a/E-Decompiler/EAppControl/EAppControl.h
+++ b/E-Decompiler/EAppControl/EAppControl.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <string>
 #include <vector>
 #include "../ELib.h"
@@ -6,31 +6,31 @@
 struct EAppControl
 {
 public:
-	//È¡ÊÂ¼şË÷Òı¶ÔÓ¦µÄÃû³Æ
+	//å–äº‹ä»¶ç´¢å¼•å¯¹åº”çš„åç§°
 	virtual std::string GetEventName(int eventIndex) = 0;
-	//¼ÓÔØ¿Ø¼ş¸½¼ÓÊôĞÔÊı¾İ
+	//åŠ è½½æ§ä»¶é™„åŠ å±æ€§æ•°æ®
 	virtual bool InitControlExtraData(unsigned int propertyAddr, unsigned int propertySize);
-	//»ñÈ¡ÊôĞÔÃû³Æ
+	//è·å–å±æ€§åç§°
 	virtual std::string GetPropertyName(unsigned int propertyIndex) = 0;
-	//¹«¹²ÊÂ¼şÃû³Æ
+	//å…¬å…±äº‹ä»¶åç§°
 	std::string GetCommonEventName(int eventIndex);
 public:
 	eSymbol_ControlType type;
-	//¿Ø¼şËùÊô´°¿ÚID
+	//æ§ä»¶æ‰€å±çª—å£ID
 	unsigned int windowID;
-	//¿Ø¼ş×ÔÉíID
+	//æ§ä»¶è‡ªèº«ID
 	unsigned int controlId;
-	//¿Ø¼şÃû³Æ
+	//æ§ä»¶åç§°
 	std::string controlName;
-	//¿Ø¼şËùÊôÊı¾İÀàĞÍµÄID
+	//æ§ä»¶æ‰€å±æ•°æ®ç±»å‹çš„ID
 	unsigned int controlTypeId;
-	//¿Ø¼şÀàĞÍÃû³Æ
+	//æ§ä»¶ç±»å‹åç§°
 	std::string controlTypeName;
-	//ÊôĞÔµØÖ·
+	//å±æ€§åœ°å€
 	unsigned int propertyAddr;
-	//ÊôĞÔ´óĞ¡
+	//å±æ€§å¤§å°
 	int propertySize;
-	//ÊÂ¼ş´¦Àí
+	//äº‹ä»¶å¤„ç†
 	std::vector<eSymbol_EventInfo> eventList;
 };
 

--- a/E-Decompiler/EAppControl/EAppControlFactory.cpp
+++ b/E-Decompiler/EAppControl/EAppControlFactory.cpp
@@ -1,4 +1,4 @@
-#include "EAppControlFactory.h"
+ï»¿#include "EAppControlFactory.h"
 #include "../ESymbol.h"
 #include "../Utils/Common.h"
 #include "CKrnl_window.h"
@@ -37,60 +37,60 @@ EAppControlFactory& EAppControlFactory::Instance()
 
 void EAppControlFactory::RegisterEAppControl(std::string eControlLibInfo,unsigned int controlTypeId)
 {
-	//¿âGuid + ¿Ø¼şÃû³Æ => ¿Ø¼şÀàĞÍ
+	//åº“Guid + æ§ä»¶åç§° => æ§ä»¶ç±»å‹
 	static std::map<std::string, fCreateEAppControl> tmpControlMap;
 	if (!tmpControlMap.size()) {
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325´°¿Ú"] = fCreateEAppControl(CKrnl_window::create);
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325²Ëµ¥"] = fCreateEAppControl(CKrnl_Menu::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325±à¼­¿ò"] = fCreateEAppControl(CKrnl_EditBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325Í¼Æ¬¿ò"] = fCreateEAppControl(CKrnl_PicBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325ÍâĞÎ¿ò"] = fCreateEAppControl(CKrnl_ShapeBox::create);;
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325»­°å"] = fCreateEAppControl(CKrnl_DrawPanel::create);;
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325·Ö×é¿ò"] = fCreateEAppControl(CKrnl_GroupBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325±êÇ©"] = fCreateEAppControl(CKrnl_Label::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325°´Å¥"] = fCreateEAppControl(CKrnl_Button::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325Ñ¡Ôñ¿ò"] = fCreateEAppControl(CKrnl_CheckBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325µ¥Ñ¡¿ò"] = fCreateEAppControl(CKrnl_RadioBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325×éºÏ¿ò"] = fCreateEAppControl(CKrnl_ComboBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325ÁĞ±í¿ò"] = fCreateEAppControl(CKrnl_ListBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325Ñ¡ÔñÁĞ±í¿ò"] = fCreateEAppControl(CKrnl_ChkListBox::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325ºáÏò¹ö¶¯Ìõ"] = fCreateEAppControl(CKrnl_HScrollBar::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325×İÏò¹ö¶¯Ìõ"] = fCreateEAppControl(CKrnl_VScrollBar::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325½ø¶ÈÌõ"] = fCreateEAppControl(CKrnl_ProcessBar::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325»¬¿éÌõ"] = fCreateEAppControl(CKrnl_SliderBar::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325Ñ¡Ôñ¼Ğ"] = fCreateEAppControl(CKrnl_Tab::create);
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325Ó°Ïñ¿ò"] = fCreateEAppControl(CKrnl_AnimateBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325çª—å£"] = fCreateEAppControl(CKrnl_window::create);
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325èœå•"] = fCreateEAppControl(CKrnl_Menu::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325ç¼–è¾‘æ¡†"] = fCreateEAppControl(CKrnl_EditBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325å›¾ç‰‡æ¡†"] = fCreateEAppControl(CKrnl_PicBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325å¤–å½¢æ¡†"] = fCreateEAppControl(CKrnl_ShapeBox::create);;
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325ç”»æ¿"] = fCreateEAppControl(CKrnl_DrawPanel::create);;
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325åˆ†ç»„æ¡†"] = fCreateEAppControl(CKrnl_GroupBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325æ ‡ç­¾"] = fCreateEAppControl(CKrnl_Label::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325æŒ‰é’®"] = fCreateEAppControl(CKrnl_Button::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325é€‰æ‹©æ¡†"] = fCreateEAppControl(CKrnl_CheckBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325å•é€‰æ¡†"] = fCreateEAppControl(CKrnl_RadioBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325ç»„åˆæ¡†"] = fCreateEAppControl(CKrnl_ComboBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325åˆ—è¡¨æ¡†"] = fCreateEAppControl(CKrnl_ListBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325é€‰æ‹©åˆ—è¡¨æ¡†"] = fCreateEAppControl(CKrnl_ChkListBox::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325æ¨ªå‘æ»šåŠ¨æ¡"] = fCreateEAppControl(CKrnl_HScrollBar::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325çºµå‘æ»šåŠ¨æ¡"] = fCreateEAppControl(CKrnl_VScrollBar::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325è¿›åº¦æ¡"] = fCreateEAppControl(CKrnl_ProcessBar::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325æ»‘å—æ¡"] = fCreateEAppControl(CKrnl_SliderBar::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325é€‰æ‹©å¤¹"] = fCreateEAppControl(CKrnl_Tab::create);
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325å½±åƒæ¡†"] = fCreateEAppControl(CKrnl_AnimateBox::create);
 
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325ÈÕÆÚ¿ò"] = krnl_DatePicker;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325ÔÂÀú"] = krnl_MonthCalendar;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Çı¶¯Æ÷¿ò"] = krnl_DriverBox;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Ä¿Â¼¿ò"] = krnl_DirBox;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325ÎÄ¼ş¿ò"] = krnl_FileBox;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325ÑÕÉ«Ñ¡ÔñÆ÷"] = krnl_ColorPicker;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325³¬¼¶Á´½ÓÆ÷"] = krnl_HyperLinker;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325µ÷½ÚÆ÷"] = krnl_Spin;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Í¨ÓÃ¶Ô»°¿ò"] = krnl_CommonDlg;
-		tmpControlMap["d09f2340818511d396f6aaf844c7e325Ê±ÖÓ"] = fCreateEAppControl(CKrnl_Timer::create);
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325´òÓ¡»ú"] = krnl_printer;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Êı¾İ±¨"] = krnl_UDP;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325¿Í»§"] = krnl_Client;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325·şÎñÆ÷"] = krnl_Server;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325¶Ë¿Ú"] = krnl_SerialPort;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325±í¸ñ"] = krnl_Grid;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Êı¾İÔ´"] = krnl_DataSrc;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Í¨ÓÃÌá¹©Õß"] = krnl_NProvider;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Êı¾İ¿âÌá¹©Õß"] = krnl_DBProvider;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Í¼ĞÎ°´Å¥"] = krnl_PicBtn;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Íâ²¿Êı¾İ¿â"] = krnl_ODBCDB;
-		//tmpControlMap["d09f2340818511d396f6aaf844c7e325Íâ²¿Êı¾İÌá¹©Õß"] = krnl_ODBCProvider;
-		//tmpControlMap["{9DA96BF9CEBD45c5BFCF94CBE61671F5}ÍÏ·Å¶ÔÏó"] = krnl_DropTarget;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æ—¥æœŸæ¡†"] = krnl_DatePicker;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æœˆå†"] = krnl_MonthCalendar;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325é©±åŠ¨å™¨æ¡†"] = krnl_DriverBox;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325ç›®å½•æ¡†"] = krnl_DirBox;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æ–‡ä»¶æ¡†"] = krnl_FileBox;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325é¢œè‰²é€‰æ‹©å™¨"] = krnl_ColorPicker;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325è¶…çº§é“¾æ¥å™¨"] = krnl_HyperLinker;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325è°ƒèŠ‚å™¨"] = krnl_Spin;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325é€šç”¨å¯¹è¯æ¡†"] = krnl_CommonDlg;
+		tmpControlMap["d09f2340818511d396f6aaf844c7e325æ—¶é’Ÿ"] = fCreateEAppControl(CKrnl_Timer::create);
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æ‰“å°æœº"] = krnl_printer;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æ•°æ®æŠ¥"] = krnl_UDP;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325å®¢æˆ·"] = krnl_Client;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æœåŠ¡å™¨"] = krnl_Server;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325ç«¯å£"] = krnl_SerialPort;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325è¡¨æ ¼"] = krnl_Grid;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æ•°æ®æº"] = krnl_DataSrc;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325é€šç”¨æä¾›è€…"] = krnl_NProvider;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325æ•°æ®åº“æä¾›è€…"] = krnl_DBProvider;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325å›¾å½¢æŒ‰é’®"] = krnl_PicBtn;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325å¤–éƒ¨æ•°æ®åº“"] = krnl_ODBCDB;
+		//tmpControlMap["d09f2340818511d396f6aaf844c7e325å¤–éƒ¨æ•°æ®æä¾›è€…"] = krnl_ODBCProvider;
+		//tmpControlMap["{9DA96BF9CEBD45c5BFCF94CBE61671F5}æ‹–æ”¾å¯¹è±¡"] = krnl_DropTarget;
 
-		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CC³¬¼¶°´Å¥"] = fCreateEAppControl(CIext2_SuperBtn::create);
-		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CC¸ß¼¶Ó°Ïñ¿ò"] = fCreateEAppControl(CIext2_SuperAnimateBox::create);
-		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CC·Ö¸îÌõ"] = fCreateEAppControl(CIext2_SplitterBar::create);
-		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CC³¬¼¶±à¼­¿ò"] = fCreateEAppControl(CIext2_RichEdit::create);
-		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCIP±à¼­¿ò"] = fCreateEAppControl(CIext2_IPEditBox::create);
-		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CC¶¯»­¿ò"] = fCreateEAppControl(CIext2_CartoonBox::create);
+		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCè¶…çº§æŒ‰é’®"] = fCreateEAppControl(CIext2_SuperBtn::create);
+		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCé«˜çº§å½±åƒæ¡†"] = fCreateEAppControl(CIext2_SuperAnimateBox::create);
+		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCåˆ†å‰²æ¡"] = fCreateEAppControl(CIext2_SplitterBar::create);
+		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCè¶…çº§ç¼–è¾‘æ¡†"] = fCreateEAppControl(CIext2_RichEdit::create);
+		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCIPç¼–è¾‘æ¡†"] = fCreateEAppControl(CIext2_IPEditBox::create);
+		tmpControlMap["AF6AD80AA4244A59AFB3D83ECF5173CCåŠ¨ç”»æ¡†"] = fCreateEAppControl(CIext2_CartoonBox::create);
 	}
 
 	std::map<std::string, fCreateEAppControl>::iterator it = tmpControlMap.find(eControlLibInfo);
@@ -119,7 +119,7 @@ EAppControl_Unknow* EAppControl_Unknow::create()
 
 std::string EAppControl_Unknow::GetEventName(int eventIndex)
 {
-	return "Î´ÖªÊÂ¼ş";
+	return "æœªçŸ¥äº‹ä»¶";
 }
 
 bool EAppControl_Unknow::InitControlExtraData(unsigned int propertyAddr, unsigned int propertySize)
@@ -129,5 +129,5 @@ bool EAppControl_Unknow::InitControlExtraData(unsigned int propertyAddr, unsigne
 
 std::string EAppControl_Unknow::GetPropertyName(unsigned int propertyIndex)
 {
-	return "Î´Öª";
+	return "æœªçŸ¥";
 }

--- a/E-Decompiler/EAppControl/EAppControlFactory.h
+++ b/E-Decompiler/EAppControl/EAppControlFactory.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <map>
 #include <string>
 

--- a/E-Decompiler/ECSigParser.cpp
+++ b/E-Decompiler/ECSigParser.cpp
@@ -1,4 +1,4 @@
-#include "ECSigParser.h"
+ï»¿#include "ECSigParser.h"
 #include <funcs.hpp>
 #include <bytes.hpp>
 #include <segment.hpp>
@@ -12,7 +12,9 @@
 #include "SectionManager.h"
 #include "ImportsParser.h"
 #include "EDecompiler.h"
-#include "common/public.h"
+#include "./Utils/Common.h"
+#include "./Utils/Strings.h"
+
 
 eSymbol_KrnlJmp ECSigParser::m_KrnlJmp;
 std::map<ea_t, qstring> ECSigParser::mMap_BasicFunc;
@@ -135,7 +137,7 @@ qstring ECSigParser::GetSig_LongJmp(insn_t& ins)
 	qstring ret;
 	unsigned char* pData = SectionManager::LinearAddrToVirtualAddr(ins.ip);
 
-	//³¤Ìø×ªÍ³Ò»Ä£ºı´¦Àí
+	//é•¿è·³è½¬ç»Ÿä¸€æ¨¡ç³Šå¤„ç†
 	if (ins.size >= 5) {
 		ret.append(UCharToStr(pData[0]));
 		return ret;
@@ -180,7 +182,7 @@ qstring ECSigParser::GetSig_Call(insn_t& ins, qvector<qstring>& vec_saveSig,bool
 {
 	qstring ret;
 	if (ins.ops[0].type == o_near) {
-		//´íÎó»Øµ÷º¯Êı
+		//é”™è¯¯å›è°ƒå‡½æ•°
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MReportError) {
 			ea_t lastInsAddr = ins.ip;
 			out_bSkipState = true;
@@ -195,20 +197,20 @@ qstring ECSigParser::GetSig_Call(insn_t& ins, qvector<qstring>& vec_saveSig,bool
 			}
 			else if (isJumpInst(LastIns.itype)) {
 				vec_saveSig[vec_saveSig.size() - 2] = "";
-				return getUTF8String("<´íÎó»Øµ÷>");
+				return getUTF8String("<é”™è¯¯å›è°ƒ>");
 			}
 			lastInsAddr = decode_prev_insn(&LastIns, lastInsAddr);
 			if (LastIns.itype == NN_push && LastIns.ops[0].type == o_imm) {
 				vec_saveSig[vec_saveSig.size() - 3] = "";
 				vec_saveSig[vec_saveSig.size() - 4] = "";
 			}
-			return getUTF8String("<´íÎó»Øµ÷>");
+			return getUTF8String("<é”™è¯¯å›è°ƒ>");
 		}
-		//µ÷ÓÃDLLÃüÁî
+		//è°ƒç”¨DLLå‘½ä»¤
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MCallDllCmd) {
 			insn_t LastIns;
 			decode_prev_insn(&LastIns, ins.ip);
-			//ÅĞ¶ÏÉÏÒ»ÌõÖ¸ÁîÊÇ²»ÊÇmov eax,DLLĞòºÅ
+			//åˆ¤æ–­ä¸Šä¸€æ¡æŒ‡ä»¤æ˜¯ä¸æ˜¯mov eax,DLLåºå·
 			if (LastIns.itype == NN_mov && LastIns.ops[0].reg == 0 && LastIns.ops[1].type == o_imm) {
 				vec_saveSig[vec_saveSig.size() - 1] = "B8????????";
 				qstring DLLFuncName = ImportsParser::mVec_ImportsApi[LastIns.ops[1].value].ApiName;
@@ -216,20 +218,20 @@ qstring ECSigParser::GetSig_Call(insn_t& ins, qvector<qstring>& vec_saveSig,bool
 				return ret;
 			}
 		}
-		//ÏµÍ³ºËĞÄÖ§³Ö¿â»òÕßÈı·½Ö§³Ö¿â
+		//ç³»ç»Ÿæ ¸å¿ƒæ”¯æŒåº“æˆ–è€…ä¸‰æ–¹æ”¯æŒåº“
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MCallKrnlLibCmd || ins.ops[0].addr==m_KrnlJmp.Jmp_MCallLibCmd) {
 			insn_t LastIns;
 			decode_prev_insn(&LastIns, ins.ip);
-			//ÅĞ¶ÏÉÏÒ»ÌõÖ¸ÁîÊÇ²»ÊÇmov ebx,ÃüÁîµØÖ·
+			//åˆ¤æ–­ä¸Šä¸€æ¡æŒ‡ä»¤æ˜¯ä¸æ˜¯mov ebx,å‘½ä»¤åœ°å€
 			if (LastIns.itype == NN_mov && LastIns.ops[0].reg == 3 && LastIns.ops[1].type == o_imm) {
 				vec_saveSig[vec_saveSig.size() - 1] = "BB????????";
 				if (bFuzzySig) {
-					return getUTF8String("<Î´ÖªÃüÁî>");
+					return getUTF8String("<æœªçŸ¥å‘½ä»¤>");
 				}
 				qstring KrnlLibName = get_name(LastIns.ops[1].value);
 				if (KrnlLibName.substr(0, 4) == "sub_") {
 					msg("[GetSig_Call]Function not Scanned,%a", LastIns.ops[1].value);
-					ret = getUTF8String("<Î´ÖªÃüÁî>");
+					ret = getUTF8String("<æœªçŸ¥å‘½ä»¤>");
 					return ret;
 				}
 				ret.sprnt("<%s>", KrnlLibName.c_str());
@@ -237,31 +239,31 @@ qstring ECSigParser::GetSig_Call(insn_t& ins, qvector<qstring>& vec_saveSig,bool
 			}
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MReadProperty) {
-			ret = getUTF8String("<¶ÁÈ¡×é¼şÊôĞÔ>");
+			ret = getUTF8String("<è¯»å–ç»„ä»¶å±æ€§>");
 			return ret;
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MWriteProperty) {
-			ret = getUTF8String("<ÉèÖÃ×é¼şÊôĞÔ>");
+			ret = getUTF8String("<è®¾ç½®ç»„ä»¶å±æ€§>");
 			return ret;
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MMalloc) {
-			ret = getUTF8String("<·ÖÅäÄÚ´æ>");
+			ret = getUTF8String("<åˆ†é…å†…å­˜>");
 			return ret;
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MRealloc) {
-			ret = getUTF8String("<ÖØĞÂ·ÖÅäÄÚ´æ>");
+			ret = getUTF8String("<é‡æ–°åˆ†é…å†…å­˜>");
 			return ret;
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MFree) {
-			ret = getUTF8String("<ÊÍ·ÅÄÚ´æ>");
+			ret = getUTF8String("<é‡Šæ”¾å†…å­˜>");
 			return ret;
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MExitProcess) {
-			ret = getUTF8String("<½áÊø>");
+			ret = getUTF8String("<ç»“æŸ>");
 			return ret;
 		}
 		if (ins.ops[0].addr == m_KrnlJmp.Jmp_MOtherHelp) {
-			ret = getUTF8String("<¸¨Öúº¯Êı>");
+			ret = getUTF8String("<è¾…åŠ©å‡½æ•°>");
 			return ret;
 		}
 		//call $addr+0x5
@@ -270,17 +272,18 @@ qstring ECSigParser::GetSig_Call(insn_t& ins, qvector<qstring>& vec_saveSig,bool
 		}
 		auto it = mMap_BasicFunc.find(ins.ops[0].addr);
 		if (it != mMap_BasicFunc.end()) {
-			ret.sprnt("<%s>", getUTF8String(it->second.c_str()).c_str());
+			// mMap_BasicFunc å­˜å‚¨çš„å·²æ˜¯ UTF-8
+			ret.sprnt("<%s>", it->second.c_str());
 			return ret;
 		}
-		//ÓÃ»§×Ô¶¨Òåº¯Êı
+		//ç”¨æˆ·è‡ªå®šä¹‰å‡½æ•°
 		qstring subFuncName = mSave_SubFunc[ins.ops[0].addr];
 		if (subFuncName.empty()) {
-			//·ÀÖ¹µİ¹éÑ­»·
+			//é˜²æ­¢é€’å½’å¾ªç¯
 			mSave_SubFunc[ins.ops[0].addr] = "<RecurFunc>";
 			subFuncName = GetFunctionMD5(ins.ops[0].addr);
 			if (subFuncName.empty()) {
-				//±íÊ¾¸Ãº¯ÊıÆäÊµÊÇÖÃÈë´úÂë
+				//è¡¨ç¤ºè¯¥å‡½æ•°å…¶å®æ˜¯ç½®å…¥ä»£ç 
 				ret = GetInsHex(ins);
 				mSave_SubFunc[ins.ops[0].addr] = ret;
 				return ret;
@@ -675,13 +678,13 @@ void ECSigParser::ScanMSig(const char* lpsigPath, ea_t rangeStart, ea_t rangeEnd
 	//	if (funcCount == 1) {
 	//		auto it = map_MSig.find(goodMD5);
 	//		//setFuncName(pFunc->start_ea, it->second.c_str(), SN_FORCE);
-	//		msg("%s%a--%s\n", getUTF8String("Ê¶±ğÄ£¿éº¯Êı").c_str(), pFunc->start_ea, getUTF8String(it->second.c_str()).c_str());
+	//		msg("%s%a--%s\n", getUTF8String("è¯†åˆ«æ¨¡å—å‡½æ•°").c_str(), pFunc->start_ea, getUTF8String(it->second.c_str()).c_str());
 	//		continue;
 	//	}
 	//	else if (funcCount != 0) {
 	//		auto it = map_MSig.find(goodMD5);
 	//		//setFuncName(pFunc->start_ea, it->second.c_str());
-	//		msg("%s%a--%s\n", getUTF8String("Ê¶±ğÄ£¿éº¯Êı").c_str(), pFunc->start_ea, getUTF8String(it->second.c_str()).c_str());
+	//		msg("%s%a--%s\n", getUTF8String("è¯†åˆ«æ¨¡å—å‡½æ•°").c_str(), pFunc->start_ea, getUTF8String(it->second.c_str()).c_str());
 	//		continue;
 	//	}
 	//	
@@ -703,7 +706,7 @@ void ECSigParser::ScanMSig(const char* lpsigPath, ea_t rangeStart, ea_t rangeEnd
 	//	if (funcCount) {
 	//		auto it = map_MSig.find(badMD5);
 	//		//setFuncName(pFunc->start_ea, it->second.c_str());
-	//		msg("%s%a--%s\n", getUTF8String("Ê¶±ğÄ£¿éº¯Êı").c_str(), pFunc->start_ea, getUTF8String(it->second.c_str()).c_str());
+	//		msg("%s%a--%s\n", getUTF8String("è¯†åˆ«æ¨¡å—å‡½æ•°").c_str(), pFunc->start_ea, getUTF8String(it->second.c_str()).c_str());
 	//		continue;
 	//	}
 	//	if (funcCount != 0) {
@@ -717,7 +720,12 @@ void ECSigParser::ScanMSig(const char* lpsigPath, ea_t rangeStart, ea_t rangeEnd
 qstring ECSigParser::GetFunctionMD5(ea_t FuncStartAddr)
 {
 	qstring ret_MD5;
+	func_t* pFunc = get_func(FuncStartAddr);
+	if (!pFunc) {
+		return ret_MD5;
+	}
 	ea_t startAddr = pFunc->start_ea;
+	ea_t endAddr = pFunc->end_ea;
 	qvector<qstring> vec_SaveSig;
 	bool bSkipNextIns = false;
 	do
@@ -814,11 +822,11 @@ qstring ECSigParser::GetFunctionMD5(ea_t FuncStartAddr)
 		case NN_call:
 			tmpSig = GetSig_Call(CurrentIns, vec_SaveSig, bSkipNextIns);
 			break;
-		//nopÖ¸ÁîµÄ´¦ÀíÊÇ¸öÀıÍâ,Õâ¸öÊÇÔ¤Áô¸øÒ×ÓïÑÔµÄ»¨Ö¸ÁîµÄ
+		//nopæŒ‡ä»¤çš„å¤„ç†æ˜¯ä¸ªä¾‹å¤–,è¿™ä¸ªæ˜¯é¢„ç•™ç»™æ˜“è¯­è¨€çš„èŠ±æŒ‡ä»¤çš„
 		case NN_nop:
 			tmpSig = "";
 			break;
-		//·ÇÒ×ÓïÑÔÖ¸Áî(¹Û²ìÖĞ)
+		//éæ˜“è¯­è¨€æŒ‡ä»¤(è§‚å¯Ÿä¸­)
 		case NN_lea:
 		case NN_setnz:
 		case NN_setz:
@@ -845,7 +853,7 @@ qstring ECSigParser::GetFunctionMD5(ea_t FuncStartAddr)
 		case NN_retf:
 			tmpSig = GetInsHex(CurrentIns);
 			break;
-			//·ÇÒ×ÓïÑÔÖ¸Áî(¸ß¶ÈÈ·ÈÏ)
+			//éæ˜“è¯­è¨€æŒ‡ä»¤(é«˜åº¦ç¡®è®¤)
 		case NN_aaa:
 		case NN_aad:
 		case NN_aam:
@@ -885,7 +893,7 @@ qstring ECSigParser::GetFunctionMD5(ea_t FuncStartAddr)
 		case NN_vmovdqu:
 			tmpSig = GetInsHex(CurrentIns);
 			break;
-		//ÎŞĞè·ÖÎöµÄÖ¸Áî
+		//æ— éœ€åˆ†æçš„æŒ‡ä»¤
 		case NN_lods:
 		case NN_stos:
 		case NN_retn:
@@ -899,7 +907,7 @@ qstring ECSigParser::GetFunctionMD5(ea_t FuncStartAddr)
 
 		vec_SaveSig.push_back(tmpSig);
 		if (tmpSig.empty() && CurrentIns.itype != NN_nop) {
-			msg("%s--%a\n", getUTF8String("»ñÈ¡ÌØÕ÷Ê§°Ü").c_str(), startAddr);
+			msg("%s--%a\n", getUTF8String("è·å–ç‰¹å¾å¤±è´¥").c_str(), startAddr);
 		}
 		startAddr = startAddr + CurrentIns.size;
 

--- a/E-Decompiler/ECSigParser.h
+++ b/E-Decompiler/ECSigParser.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <pro.h>
 #include <set>
 #include <map>
@@ -9,43 +9,43 @@ class func_t;
 class ECSigParser
 {
 public:
-	//Éú³ÉÒ×ÓïÑÔÄ£¿éº¯ÊıÌØÕ÷Âë
+	//ç”Ÿæˆæ˜“è¯­è¨€æ¨¡å—å‡½æ•°ç‰¹å¾ç 
 	static int GenerateECSig(ea_t startAddr);
 	static void InitECSigKrnl(eSymbol_KrnlJmp& inFunc);
 	static void InitECSigBasciFunc(std::map<ea_t, qstring>& mhash);
 	static void InitECSigResource(uint32 startAddr, uint32 endAddr);
 	static void ScanMSig(const char* sigPath, ea_t rangeStart, ea_t rangeEnd);
-	//µ÷ÊÔÄ£Ê½ÏÂ×¨ÓÃ£¬ÅúÁ¿Éú³ÉÌØÕ÷Âë
+	//è°ƒè¯•æ¨¡å¼ä¸‹ä¸“ç”¨ï¼Œæ‰¹é‡ç”Ÿæˆç‰¹å¾ç 
 	static void Debug_outputECSig();
 private:
-	//¼ÆËãÒ»¸öÓÃ»§º¯ÊıµÄMD5
+	//è®¡ç®—ä¸€ä¸ªç”¨æˆ·å‡½æ•°çš„MD5
 	static qstring GetFunctionMD5(ea_t FuncStartAddr);
-	//¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª¡ª
-	//Áé»îµÄµ¥²Ù×÷ÊıÖ¸Áî
+	//â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”â€”
+	//çµæ´»çš„å•æ“ä½œæ•°æŒ‡ä»¤
 	static qstring GetSig_FlexSingleInst(insn_t& ins);
-	//Áé»îµÄË«²Ù×÷ÊıÖ¸Áî
+	//çµæ´»çš„åŒæ“ä½œæ•°æŒ‡ä»¤
 	static qstring GetSig_FlexDoubleInst(insn_t& ins);
-	//¸¡µãÖ¸Áî
+	//æµ®ç‚¹æŒ‡ä»¤
 	static qstring GetSig_FloatInstA(insn_t& ins);
 	static qstring GetSig_FloatInstB(insn_t& ins);
-	//Âß¼­ÔËËãÖ¸Áî
+	//é€»è¾‘è¿ç®—æŒ‡ä»¤
 	static qstring GetSig_LogicInst(insn_t& ins);
 	static qstring GetSig_Imul(insn_t& ins);
 	static qstring GetSig_Pop(insn_t& ins);
 	static qstring GetSig_LongJmp(insn_t& ins);
 	static qstring GetSig_Call(insn_t& ins, qvector<qstring>& vec_saveSig, bool& out_bSkipState);
 	static qstring GetSig_Nop(insn_t& ins);
-	//¼ì²éÊÇ·ñÎªÒ×ÓïÑÔ±ê×¼º¯Êı£¬²ÎÊıÎªº¯ÊıÆğÊ¼µØÖ·
+	//æ£€æŸ¥æ˜¯å¦ä¸ºæ˜“è¯­è¨€æ ‡å‡†å‡½æ•°ï¼Œå‚æ•°ä¸ºå‡½æ•°èµ·å§‹åœ°å€
 	static bool IsEStandardFunction(ea_t startAddr);
-	//Ñ°ÕÒÒ×ÓïÑÔ±ê×¼º¯ÊıÎ²²¿,²ÎÊıÎªº¯ÊıÆğÊ¼µØÖ·,·µ»Ø×îºóÒ»ÌõÖ¸ÁîµÄµØÖ·
+	//å¯»æ‰¾æ˜“è¯­è¨€æ ‡å‡†å‡½æ•°å°¾éƒ¨,å‚æ•°ä¸ºå‡½æ•°èµ·å§‹åœ°å€,è¿”å›æœ€åä¸€æ¡æŒ‡ä»¤çš„åœ°å€
 	static ea_t SeachEFuncEnd(func_t* startAddr);
-	//ÅĞ¶ÏÒ»¸ö³£Á¿ÊÇ·ñÔÚÓÃ»§×ÊÔ´µØÖ··¶Î§Ö®ÄÚ
+	//åˆ¤æ–­ä¸€ä¸ªå¸¸é‡æ˜¯å¦åœ¨ç”¨æˆ·èµ„æºåœ°å€èŒƒå›´ä¹‹å†…
 	static bool IsUserResourceImm(uint32 imm);
-	//ÅĞ¶ÏÒ»¸öÆ«ÒÆµØÖ·ÊÇ·ñÔÚÓÃ»§×ÊÔ´µØÖ··¶Î§Ö®ÄÚ
+	//åˆ¤æ–­ä¸€ä¸ªåç§»åœ°å€æ˜¯å¦åœ¨ç”¨æˆ·èµ„æºåœ°å€èŒƒå›´ä¹‹å†…
 	static bool IsUserResourceOffset(uint32 offset);
-	//Èı¶ÎÊ½Ö¸ÁîÈ¡Ä£ºıÌØÕ÷
+	//ä¸‰æ®µå¼æŒ‡ä»¤å–æ¨¡ç³Šç‰¹å¾
 	static qstring GetInsPattern_Three(insn_t& ins);
-	//Á½¶ÎÊ½Ö¸ÁîÈ¡Ä£ºıÌØÕ÷
+	//ä¸¤æ®µå¼æŒ‡ä»¤å–æ¨¡ç³Šç‰¹å¾
 	static qstring GetInsPattern_Two(insn_t& ins, char offset);
 private:
 	static eSymbol_KrnlJmp m_KrnlJmp;
@@ -54,6 +54,6 @@ private:
 	static uint32 m_UserResourceEndAddr;
 	static std::map<ea_t, qstring> mSave_SubFunc;
 
-	//Ä£ºıÌØÕ÷
+	//æ¨¡ç³Šç‰¹å¾
 	static bool bFuzzySig;
 };

--- a/E-Decompiler/EDecompiler.cpp
+++ b/E-Decompiler/EDecompiler.cpp
@@ -10,7 +10,24 @@
 #include "./Module/ShowImports.h"
 #include "./Utils/Strings.h"
 
-hexdsp_t* hexdsp = NULL;
+// HEXRAYS_API_MAGIC 的尾数是 hexrays API 版本, 随引擎构建日期变化:
+//   IDA 9.4.0 正式版引擎 (2026-07 之后) = 5
+//   更早的 9.4 build (如 260610)        = 4
+// 版本不匹配时握手会被引擎拒绝, 插件无法加载。
+// 构建时通过 EDEC_HEXRAYS_API_VERSION 指定 (见 CMakeLists.txt)。
+#ifndef EDEC_HEXRAYS_API_VERSION
+#define EDEC_HEXRAYS_API_VERSION 5
+#endif
+
+static bool edec_init_hexrays(int flags = 0)
+{
+	constexpr int64 magic = 0x00DEC0DE00000000LL + EDEC_HEXRAYS_API_VERSION;
+	hexdsp_t* dummy = nullptr;
+	return callui(ui_broadcast, magic, &dummy, flags).i == (magic >> 32);
+}
+
+// Hex-Rays 初始化状态 (定义在文件尾部 init() 附近)
+static bool gHexRaysReady = false;
 
 ssize_t PluginUI_Callback(void* ud, int notification_code, va_list va)
 {
@@ -35,7 +52,7 @@ void EDecompiler::makeFunction(ea_t startAddr, ea_t endAddr)
 	parse_binpat_str(&FuncHeadBin, 0, "55 8B EC", 16);
 	while (true)
 	{
-		startAddr = bin_search2(startAddr, endAddr, FuncHeadBin, 0x0);
+		startAddr = bin_search(startAddr, endAddr, FuncHeadBin, 0x0);
 		if (startAddr == BADADDR)
 		{
 			break;
@@ -80,7 +97,14 @@ EDecompiler::~EDecompiler()
 
 bool idaapi EDecompiler::run(size_t)
 {
-	show_wait_box(LocalCpToUtf8("等待IDA初始化分析完毕").c_str());
+	if (!gHexRaysReady) {
+		gHexRaysReady = edec_init_hexrays();
+	}
+	if (!gHexRaysReady) {
+		msg("[E-Decompiler] Hex-Rays 初始化失败, 反编译修正功能不可用 (详见 IDA9.4-PORT.md)\n");
+		return false;
+	}
+	show_wait_box("等待IDA初始化分析完毕");
 	auto_wait();
 	hide_wait_box();
 	if (!this->InitDecompilerEngine()) {
@@ -104,10 +128,10 @@ bool EDecompiler::InitDecompilerEngine()
 	eControlXref.RegisterAction(this);
 
 	if (eSymbol.allControlList.size() > 0) {
-		gMenu_ShowEventInfo = IDAMenu::CreateMenu(LocalCpToUtf8("易语言/控件事件信息").c_str(), ShowEventList, &eSymbol);
+		gMenu_ShowEventInfo = IDAMenu::CreateMenu("易语言/控件事件信息", ShowEventList, &eSymbol);
 	}
 	if (eSymbol.tmpImportsApiList.size() > 0) {
-		gMenu_ShowGUIInfo = IDAMenu::CreateMenu(LocalCpToUtf8("易语言/用户导入表").c_str(), ShowImports, &eSymbol);
+		gMenu_ShowGUIInfo = IDAMenu::CreateMenu("易语言/用户导入表", ShowImports, &eSymbol);
 	}
 
 	cTreeFixer.Install();
@@ -166,7 +190,7 @@ bool EDecompiler::Parse_EStatic(unsigned int eHeadAddr)
 	eSymbol.userCodeStartAddr = eHead.lpStartCode;
 	eSymbol.userCodeEndAddr = eHeadAddr;
 
-	show_wait_box(LocalCpToUtf8("扫描易语言函数").c_str());
+	show_wait_box("扫描易语言函数");
 	makeFunction(eSymbol.userCodeStartAddr, eSymbol.userCodeEndAddr);
 	auto_wait();
 	hide_wait_box();
@@ -174,12 +198,12 @@ bool EDecompiler::Parse_EStatic(unsigned int eHeadAddr)
 	return eSymbol.LoadEStaticSymbol(eHeadAddr,&eHead);
 }
 
+// Hex-Rays 初始化状态: 扫描期尝试一次, 失败则留待 run() 时重试
 static plugmod_t* idaapi init()
 {
-	// no decompiler
-	if (!init_hexrays_plugin()) {
-		return nullptr;
-	}
+	// 扫描期尝试初始化 hexrays; 失败不放弃加载, 运行期 (run) 会重试,
+	// 这样即使个别环境握手时序异常, 插件菜单/快捷键仍然可用
+	gHexRaysReady = edec_init_hexrays();
 	return new EDecompiler();
 }
 
@@ -198,6 +222,6 @@ plugin_t PLUGIN =
   comment,              // long comment about the plugin
   "fjqisba@sohu.com",   // multiline help about the plugin
   PLUGINNAME,           // the preferred short name of the plugin
-  nullptr,              // the preferred hotkey to run the plugin
+  "Ctrl-Alt-E",         // the preferred hotkey to run the plugin
 };
 

--- a/E-Decompiler/EDecompiler.h
+++ b/E-Decompiler/EDecompiler.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <pro.h>
 #include <idp.hpp>
 #include "SectionManager.h"
@@ -10,9 +10,9 @@
 
 enum EArchitectureType
 {
-	E_UNKNOWN = 0,  //Î´ÖªÀàĞÍ
-	E_DYNAMIC,      //¶¯Ì¬±àÒë³ÌĞò
-	E_STATIC,       //¾²Ì¬±àÒë³ÌĞò
+	E_UNKNOWN = 0,  //æœªçŸ¥ç±»å‹
+	E_DYNAMIC,      //åŠ¨æ€ç¼–è¯‘ç¨‹åº
+	E_STATIC,       //é™æ€ç¼–è¯‘ç¨‹åº
 };
 
 class IDAMenu;
@@ -24,18 +24,18 @@ public:
 	~EDecompiler();
 public:
 	bool idaapi run(size_t) override;
-	//³õÊ¼»¯Ò×ÓïÑÔ·´±àÒëÒıÇæ
+	//åˆå§‹åŒ–æ˜“è¯­è¨€åç¼–è¯‘å¼•æ“
 	bool InitDecompilerEngine();
 private:
-	//É¨ÃèÒ×ÓïÑÔº¯Êı
+	//æ‰«ææ˜“è¯­è¨€å‡½æ•°
 	void makeFunction(ea_t startAddr, ea_t endAddr);
 
-	//Ì½²âÒ×ÓïÑÔ³ÌĞòÀàĞÍ
+	//æ¢æµ‹æ˜“è¯­è¨€ç¨‹åºç±»å‹
 	bool initEArchitectureType();
 
 	bool Parse_EStatic(unsigned int eHeadAddr);
 
-	//µ¼ÈëÒ×ÓïÑÔÉùÃ÷
+	//å¯¼å…¥æ˜“è¯­è¨€å£°æ˜
 	void ImportsEStructure();
 public:
 	EArchitectureType arch;

--- a/E-Decompiler/ELib.h
+++ b/E-Decompiler/ELib.h
@@ -1,9 +1,9 @@
-#pragma once
+ï»¿#pragma once
 
 struct eSymbol_EventInfo
 {
-	int eventIndex;          //ÊÂ¼şË÷Òı
-	unsigned int eventAddr;  //ÊÂ¼şµØÖ·
+	int eventIndex;          //äº‹ä»¶ç´¢å¼•
+	unsigned int eventAddr;  //äº‹ä»¶åœ°å€
 };
 
 struct eSymbol_ImportsApi
@@ -15,49 +15,49 @@ struct eSymbol_ImportsApi
 enum eSymbol_ControlType
 {
 	UnknownControl = 0,
-	krnl_window,     //´°¿Ú
-	krnl_menu,       //²Ëµ¥
-	krnl_EditBox,    //±à¼­¿ò
-	krnl_PicBox,     //Í¼Æ¬¿ò
-	krnl_ShapeBox,   //ÍâĞÎ¿ò
-	krnl_DrawPanel,  //»­°å
-	krnl_GroupBox,   //·Ö×é¿ò
-	krnl_Label,      //±êÇ©
-	krnl_Button,     //°´Å¥
-	krnl_CheckBox,   //Ñ¡Ôñ¿ò
-	krnl_RadioBox,   //µ¥Ñ¡¿ò
-	krnl_ComboBox,   //×éºÏ¿ò
-	krnl_ListBox,    //ÁĞ±í¿ò
-	krnl_ChkListBox, //Ñ¡ÔñÁĞ±í¿ò
-	krnl_HScrollBar, //ºáÏò¹ö¶¯Ìõ
-	krnl_VScrollBar, //×İÏò¹ö¶¯Ìõ
-	krnl_ProcessBar, //½ø¶ÈÌõ
-	krnl_SliderBar,  //»¬¿éÌõ
-	krnl_Tab,        //Ñ¡Ôñ¼Ğ
-	krnl_AnimateBox, //Ó°Ïñ¿ò
-	krnl_DatePicker, //ÈÕÆÚ¿ò
-	krnl_MonthCalendar,  //ÔÂÀú
-	krnl_DriverBox,  //Çı¶¯Æ÷¿ò
-	krnl_DirBox,     //Ä¿Â¼¿ò
-	krnl_FileBox,    //ÎÄ¼ş¿ò
-	krnl_ColorPicker, //ÑÕÉ«Ñ¡ÔñÆ÷
-	krnl_HyperLinker, //³¬¼¶Á´½ÓÆ÷
-	krnl_Spin,        //µ÷½ÚÆ÷
-	krnl_CommonDlg,   //Í¨ÓÃ¶Ô»°¿ò
-	krnl_Timer,       //Ê±ÖÓ
-	krnl_printer,     //´òÓ¡»ú
-	krnl_UDP,         //Êı¾İ±¨
-	krnl_Client,      //¿Í»§
-	krnl_Server,      //·şÎñÆ÷
-	krnl_SerialPort,  //¶Ë¿Ú
-	krnl_Grid,        //±í¸ñ
-	krnl_DataSrc,     //Êı¾İÔ´
-	krnl_NProvider,   //Í¨ÓÃÌá¹©Õß
-	krnl_DBProvider,  //Êı¾İ¿âÌá¹©Õß
-	krnl_PicBtn,      //Í¼ĞÎ°´Å¥
-	krnl_ODBCDB,      //Íâ²¿Êı¾İ¿â
-	krnl_ODBCProvider,//Íâ²¿Êı¾İÌá¹©Õß
-	krnl_DropTarget,  //ÍÏ·Å¶ÔÏó
+	krnl_window,     //çª—å£
+	krnl_menu,       //èœå•
+	krnl_EditBox,    //ç¼–è¾‘æ¡†
+	krnl_PicBox,     //å›¾ç‰‡æ¡†
+	krnl_ShapeBox,   //å¤–å½¢æ¡†
+	krnl_DrawPanel,  //ç”»æ¿
+	krnl_GroupBox,   //åˆ†ç»„æ¡†
+	krnl_Label,      //æ ‡ç­¾
+	krnl_Button,     //æŒ‰é’®
+	krnl_CheckBox,   //é€‰æ‹©æ¡†
+	krnl_RadioBox,   //å•é€‰æ¡†
+	krnl_ComboBox,   //ç»„åˆæ¡†
+	krnl_ListBox,    //åˆ—è¡¨æ¡†
+	krnl_ChkListBox, //é€‰æ‹©åˆ—è¡¨æ¡†
+	krnl_HScrollBar, //æ¨ªå‘æ»šåŠ¨æ¡
+	krnl_VScrollBar, //çºµå‘æ»šåŠ¨æ¡
+	krnl_ProcessBar, //è¿›åº¦æ¡
+	krnl_SliderBar,  //æ»‘å—æ¡
+	krnl_Tab,        //é€‰æ‹©å¤¹
+	krnl_AnimateBox, //å½±åƒæ¡†
+	krnl_DatePicker, //æ—¥æœŸæ¡†
+	krnl_MonthCalendar,  //æœˆå†
+	krnl_DriverBox,  //é©±åŠ¨å™¨æ¡†
+	krnl_DirBox,     //ç›®å½•æ¡†
+	krnl_FileBox,    //æ–‡ä»¶æ¡†
+	krnl_ColorPicker, //é¢œè‰²é€‰æ‹©å™¨
+	krnl_HyperLinker, //è¶…çº§é“¾æ¥å™¨
+	krnl_Spin,        //è°ƒèŠ‚å™¨
+	krnl_CommonDlg,   //é€šç”¨å¯¹è¯æ¡†
+	krnl_Timer,       //æ—¶é’Ÿ
+	krnl_printer,     //æ‰“å°æœº
+	krnl_UDP,         //æ•°æ®æŠ¥
+	krnl_Client,      //å®¢æˆ·
+	krnl_Server,      //æœåŠ¡å™¨
+	krnl_SerialPort,  //ç«¯å£
+	krnl_Grid,        //è¡¨æ ¼
+	krnl_DataSrc,     //æ•°æ®æº
+	krnl_NProvider,   //é€šç”¨æä¾›è€…
+	krnl_DBProvider,  //æ•°æ®åº“æä¾›è€…
+	krnl_PicBtn,      //å›¾å½¢æŒ‰é’®
+	krnl_ODBCDB,      //å¤–éƒ¨æ•°æ®åº“
+	krnl_ODBCProvider,//å¤–éƒ¨æ•°æ®æä¾›è€…
+	krnl_DropTarget,  //æ‹–æ”¾å¯¹è±¡
 
 
 	iext2_CartoonBox,

--- a/E-Decompiler/ESymbol.cpp
+++ b/E-Decompiler/ESymbol.cpp
@@ -1,11 +1,10 @@
-#include "ESymbol.h"
+ï»¿#include "ESymbol.h"
 #include "./Utils/Strings.h"
 #include "./Utils/IDAWrapper.h"
 #include "TrieTree.h"
 #include "SectionManager.h"
 #include <ua.hpp>
 #include <allins.hpp>
-#include <struct.hpp>
 #include <typeinf.hpp>
 #include <unordered_set>
 #include <hexrays.hpp>
@@ -35,7 +34,7 @@ unsigned int krnln_GetIDGroupType(unsigned int ID)
 	return ID & 0xF000000;
 }
 
-//ÊÇ·ñÎª²Ëµ¥
+//æ˜¯å¦ä¸ºèœå•
 bool krnln_IsMenuItemID(unsigned int ID)
 {
 	return krnln_GetIDGroupType(ID) == 0x6000000 && krnln_GetIDSubType(ID) == 0x20000000;
@@ -81,7 +80,7 @@ bool ESymbol::LoadEStaticSymbol(unsigned int eHeadAddr, EComHead* eHead)
 {
 	clearControlData();
 
-	IDAWrapper::show_wait_box(LocalCpToUtf8("½âÎöÒ×ÓïÑÔÖ§³Ö¿â").c_str());
+	IDAWrapper::show_wait_box(LocalCpToUtf8("è§£ææ˜“è¯­è¨€æ”¯æŒåº“").c_str());
 	if (!loadELibInfomation(eHead->lpLibEntry, eHead->dwLibNum)) {
 		IDAWrapper::hide_wait_box();
 		return false;
@@ -89,7 +88,7 @@ bool ESymbol::LoadEStaticSymbol(unsigned int eHeadAddr, EComHead* eHead)
 	IDAWrapper::hide_wait_box();
 	
 	eSymbolFuncTypeMap.clear();
-	IDAWrapper::show_wait_box(LocalCpToUtf8("Ê¶±ğÖ§³Ö¿âº¯Êı").c_str());
+	IDAWrapper::show_wait_box(LocalCpToUtf8("è¯†åˆ«æ”¯æŒåº“å‡½æ•°").c_str());
 	if (!scanELibFunction(eHead->lpLibEntry, eHead->dwLibNum)) {
 		IDAWrapper::hide_wait_box();
 		return false;
@@ -107,29 +106,29 @@ bool ESymbol::LoadEStaticSymbol(unsigned int eHeadAddr, EComHead* eHead)
 		return false;
 	}
 
-	IDAWrapper::show_wait_box(LocalCpToUtf8("É¨ÃèÒ×ÓïÑÔÀà").c_str());
+	IDAWrapper::show_wait_box(LocalCpToUtf8("æ‰«ææ˜“è¯­è¨€ç±»").c_str());
 	scanEClassTable();
 	IDAWrapper::hide_wait_box();
 
 	if (eHead->lpEString != 0 && eHead->dwEStringSize != 0) {
-		//To do... Ò×ÓïÑÔ³£Á¿×ÊÔ´·¶Î§ÓĞÊ²Ã´ÓÃÄØ
+		//To do... æ˜“è¯­è¨€å¸¸é‡èµ„æºèŒƒå›´æœ‰ä»€ä¹ˆç”¨å‘¢
 	}
 
 	if (eHead->lpEWindow != 0 && eHead->dwEWindowSize > 4) {
-		IDAWrapper::show_wait_box(LocalCpToUtf8("½âÎöÒ×ÓïÑÔ¿Ø¼ş×ÊÔ´").c_str());
+		IDAWrapper::show_wait_box(LocalCpToUtf8("è§£ææ˜“è¯­è¨€æ§ä»¶èµ„æº").c_str());
 		loadGUIResource(eHead->lpEWindow, eHead->dwEWindowSize);
 		IDAWrapper::hide_wait_box();
 	}
 
 	if (eHead->dwApiCount) {
-		IDAWrapper::show_wait_box(LocalCpToUtf8("½âÎöÒ×ÓïÑÔµ¼Èë±í").c_str());
+		IDAWrapper::show_wait_box(LocalCpToUtf8("è§£ææ˜“è¯­è¨€å¯¼å…¥è¡¨").c_str());
 		loadUserImports(eHead->dwApiCount, eHead->lpModuleName, eHead->lpApiName);
 		IDAWrapper::hide_wait_box();
 	}
 	
 	setGuiEventName();
 
-	IDAWrapper::show_wait_box(LocalCpToUtf8("Ê¶±ğÄ£¿éº¯Êı").c_str());
+	IDAWrapper::show_wait_box(LocalCpToUtf8("è¯†åˆ«æ¨¡å—å‡½æ•°").c_str());
 	//ECSigScanner::Instance().ScanECSigFunction(this);
 	IDAWrapper::hide_wait_box();
 	return true;
@@ -157,16 +156,21 @@ bool ESymbol::loadELibInfomation(unsigned int lpLibStartAddr, unsigned int dwLib
 		IDAWrapper::get_bytes(&tmpLibInfo, sizeof(LIB_INFO), IDAWrapper::get_dword(lpLibStartAddr));
 		lpLibStartAddr = lpLibStartAddr + 4;
 
-		//ÅĞ¶ÏÊÇ·ñ·ûºÏÖ§³Ö¿â¸ñÊ½
+		//åˆ¤æ–­æ˜¯å¦ç¬¦åˆæ”¯æŒåº“æ ¼å¼
 		if (tmpLibInfo.m_dwLibFormatVer != 0x1312D65) {
 			continue;
 		}
 
 		eSymbol_ELibInfo eLibInfo;
-		eLibInfo.m_Name = IDAWrapper::get_shortstring(tmpLibInfo.m_lpName);
-		eLibInfo.m_Guid = IDAWrapper::get_shortstring(tmpLibInfo.m_lpGuid);
-		eLibInfo.m_nMajorVersion = tmpLibInfo.m_nMajorVersion;
-		eLibInfo.m_nMinorVersion = tmpLibInfo.m_nMinorVersion;
+		{
+			// äºŒè¿›åˆ¶ä¸­çš„ GBK åç§° -> UTF-8 å­˜å‚¨
+			qstring nameUtf8;
+			acp_utf8(&nameUtf8, IDAWrapper::get_shortstring(tmpLibInfo.m_lpName).c_str());
+			eLibInfo.m_Name = nameUtf8.c_str();
+			eLibInfo.m_Guid = IDAWrapper::get_shortstring(tmpLibInfo.m_lpGuid);
+			eLibInfo.m_nMajorVersion = tmpLibInfo.m_nMajorVersion;
+			eLibInfo.m_nMinorVersion = tmpLibInfo.m_nMinorVersion;
+		}
 
 		unsigned int lpFirstDataType = tmpLibInfo.m_lpDataType;
 		for (int nDataTypeIndex = 0; nDataTypeIndex < tmpLibInfo.m_nDataTypeCount; ++nDataTypeIndex) {
@@ -178,7 +182,9 @@ bool ESymbol::loadELibInfomation(unsigned int lpLibStartAddr, unsigned int dwLib
 			if (tmpDataTypeInfo.m_lpszName) {
 				controlTypeId = (nLibIndex + 1) << 0x10;
 				controlTypeId = controlTypeId + (nDataTypeIndex + 1);
-				eDataType.m_Name = IDAWrapper::get_shortstring(tmpDataTypeInfo.m_lpszName);
+				qstring dataTypeNameUtf8;
+				acp_utf8(&dataTypeNameUtf8, IDAWrapper::get_shortstring(tmpDataTypeInfo.m_lpszName).c_str());
+				eDataType.m_Name = dataTypeNameUtf8.c_str();
 				EAppControlFactory::Instance().RegisterEAppControl(eLibInfo.m_Guid + eDataType.m_Name,controlTypeId);
 			}
 			eLibInfo.mVec_DataTypeInfo.push_back(eDataType);
@@ -195,12 +201,12 @@ bool ESymbol::scanELibFunction(unsigned int lpLibStartAddr, unsigned int dwLibCo
 		IDAWrapper::get_bytes(&tmpLibInfo, sizeof(LIB_INFO), IDAWrapper::get_dword(lpLibStartAddr));
 		lpLibStartAddr = lpLibStartAddr + 4;
 
-		//ÅĞ¶ÏÊÇ·ñ·ûºÏÖ§³Ö¿â¸ñÊ½
+		//åˆ¤æ–­æ˜¯å¦ç¬¦åˆæ”¯æŒåº“æ ¼å¼
 		if (tmpLibInfo.m_dwLibFormatVer != 0x1312D65) {
 			continue;
 		}
 
-		//Ö§³Ö¿âÈ±ÉÙº¯Êı
+		//æ”¯æŒåº“ç¼ºå°‘å‡½æ•°
 		if (!tmpLibInfo.m_nCmdCount || !tmpLibInfo.m_lpCmdsFunc) {
 			continue;
 		}
@@ -229,11 +235,13 @@ bool ESymbol::scanELibFunction(unsigned int lpLibStartAddr, unsigned int dwLibCo
 			if (!pFuncName) {
 				//qstring errorFuncName;
 				IDAWrapper::msg("[ScanLibFunction]Match Function Error,%a\n", funcAddr);
-				//errorFuncName.sprnt("Î´ÖªÃüÁî_%a", funcAddr);
+				//errorFuncName.sprnt("æœªçŸ¥å‘½ä»¤_%a", funcAddr);
 				//IDAWrapper::setFuncName(funcAddr, errorFuncName.c_str());
 				continue;
 			}
-			IDAWrapper::setFuncName(funcAddr,pFuncName);
+			qstring funcNameUtf8;
+			acp_utf8(&funcNameUtf8, pFuncName); // esig æ–‡ä»¶å†…ä¸º GBK
+			IDAWrapper::setFuncName(funcAddr, funcNameUtf8.c_str());
 		}
 		qfree(pFuncBuf);
 	}
@@ -244,7 +252,7 @@ bool ESymbol::scanBasicFunction()
 {
 	TrieTree BASICTREE;
 	qstring LibPath;
-	LibPath.sprnt("%s\\esig\\Ò×ÓïÑÔ»ù´¡ÃüÁî.esig", IDAWrapper::idadir("plugins"));
+	LibPath.sprnt("%s\\esig\\æ˜“è¯­è¨€åŸºç¡€å‘½ä»¤.esig", IDAWrapper::idadir("plugins"));
 
 	std::map<ea_t, qstring> mMap_BasicFunc;
 	if (!BASICTREE.LoadSig(LibPath.c_str())) {
@@ -261,24 +269,28 @@ bool ESymbol::scanBasicFunction()
 		if (eSymbolFuncTypeMap[pFunc->start_ea] != 0x0) {
 			continue;
 		}
-		qstring funcName = BASICTREE.MatchFunc(SectionManager::LinearAddrToVirtualAddr(pFunc->start_ea));
+		char* pMatchedName = BASICTREE.MatchFunc(SectionManager::LinearAddrToVirtualAddr(pFunc->start_ea));
+		qstring funcName;
+		if (pMatchedName) {
+			acp_utf8(&funcName, pMatchedName); // esig æ–‡ä»¶å†…ä¸º GBK
+		}
 		if (!funcName.empty()) {
 			mMap_BasicFunc[pFunc->start_ea] = funcName;
 			IDAWrapper::setFuncName(pFunc->start_ea, funcName.c_str());
 		}
-		if (funcName == "ÎÄ±¾Ïà¼Ó") {
+		if (funcName == "æ–‡æœ¬ç›¸åŠ ") {
 			IDAWrapper::apply_cdecl(pFunc->start_ea, "char* __usercall strcat@<eax>(int argCount@<ecx>, ...);");
 			eSymbolFuncTypeMap[pFunc->start_ea] = eFunc_Strcat;
 		}
-		else if (funcName == "Á¬ĞøÊ¡ÂÔ²ÎÊı") {
+		else if (funcName == "è¿ç»­çœç•¥å‚æ•°") {
 			IDAWrapper::apply_cdecl(pFunc->start_ea, "void __usercall pushDefaultParam(int argCount@<ebx>);");
 			eSymbolFuncTypeMap[pFunc->start_ea] = eFunc_PushDefaultArg;
 			handleFuncPushDefaultArg(pFunc->start_ea);
 		}
-		else if (funcName == "ÎÄ±¾±È½Ï") {
+		else if (funcName == "æ–‡æœ¬æ¯”è¾ƒ") {
 			IDAWrapper::apply_cdecl(pFunc->start_ea, "int __cdecl strcmp(char* _Str1,char* _Str2);");
 		}
-		else if (funcName == "¼ÆËã¶àÎ¬Êı×éÏÂ±ê") {
+		else if (funcName == "è®¡ç®—å¤šç»´æ•°ç»„ä¸‹æ ‡") {
 			IDAWrapper::apply_cdecl(pFunc->start_ea, "int __usercall addMutilVecIndex@<edx>(int index@<eax>,int dim@<ecx>,DWORD* pBounds);");
 			eSymbolFuncTypeMap[pFunc->start_ea] = eFunc_CalMultiArrayIndex;
 		}
@@ -333,19 +345,19 @@ bool ESymbol::loadKrnlInterface(unsigned int lpKrnlEntry)
 		belowAddr += tmpIns.size;
 	} while (true);
 
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MReportError, "´íÎó»Øµ÷");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MCallDllCmd, "DLLÃüÁî");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MCallLibCmd, "Èı·½Ö§³Ö¿âÃüÁî");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MCallKrnlLibCmd, "ºËĞÄÖ§³Ö¿âÃüÁî");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MReadProperty, "¶ÁÈ¡×é¼şÊôĞÔ");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MWriteProperty, "ÉèÖÃ×é¼şÊôĞÔ");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MMalloc, "·ÖÅäÄÚ´æ");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MRealloc, "ÖØĞÂ·ÖÅäÄÚ´æ");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MFree, "ÊÍ·ÅÄÚ´æ");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MExitProcess, "½áÊø");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MMessageLoop, "´°¿ÚÏûÏ¢Ñ­»·");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MLoadBeginWin, "ÔØÈëÆô¶¯´°¿Ú");
-	IDAWrapper::setFuncName(krnlJmp.Jmp_MOtherHelp, "¸¨Öúº¯Êı");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MReportError, "é”™è¯¯å›è°ƒ");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MCallDllCmd, "DLLå‘½ä»¤");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MCallLibCmd, "ä¸‰æ–¹æ”¯æŒåº“å‘½ä»¤");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MCallKrnlLibCmd, "æ ¸å¿ƒæ”¯æŒåº“å‘½ä»¤");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MReadProperty, "è¯»å–ç»„ä»¶å±æ€§");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MWriteProperty, "è®¾ç½®ç»„ä»¶å±æ€§");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MMalloc, "åˆ†é…å†…å­˜");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MRealloc, "é‡æ–°åˆ†é…å†…å­˜");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MFree, "é‡Šæ”¾å†…å­˜");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MExitProcess, "ç»“æŸ");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MMessageLoop, "çª—å£æ¶ˆæ¯å¾ªç¯");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MLoadBeginWin, "è½½å…¥å¯åŠ¨çª—å£");
+	IDAWrapper::setFuncName(krnlJmp.Jmp_MOtherHelp, "è¾…åŠ©å‡½æ•°");
 
 	eSymbolFuncTypeMap[krnlJmp.Jmp_MReadProperty] = eFunc_KrnlReadProerty;
 	eSymbolFuncTypeMap[krnlJmp.Jmp_MWriteProperty] = eFunc_KrnlWriteProperty;
@@ -367,11 +379,11 @@ bool ESymbol::loadKrnlInterface(unsigned int lpKrnlEntry)
 
 void ESymbol::parseControlBasciProperty(unsigned char* lpControlInfo,EAppControl* outControl)
 {
-	//ÎŞÓÃ×Ö·û´®1?
+	//æ— ç”¨å­—ç¬¦ä¸²1?
 	ReadStr(lpControlInfo);
 	lpControlInfo += qstrlen(lpControlInfo) + 1;
 
-	//´æ´¢Êı¾İ?
+	//å­˜å‚¨æ•°æ®?
 	ReadUInt(lpControlInfo);
 	lpControlInfo += 4;
 
@@ -387,15 +399,15 @@ void ESymbol::parseControlBasciProperty(unsigned char* lpControlInfo,EAppControl
 	unsigned int m_height = ReadUInt(lpControlInfo);
 	lpControlInfo += 4;
 
-	//ÖµÎª0,ÓÃÀ´´æ´¢LoadCursorA·µ»ØµÄ¾ä±úÖµµÄ
+	//å€¼ä¸º0,ç”¨æ¥å­˜å‚¨LoadCursorAè¿”å›çš„å¥æŸ„å€¼çš„
 	unsigned int hCURSOR = ReadUInt(lpControlInfo);
 	lpControlInfo += 4;
 
-	//¸¸¿Ø¼şID
+	//çˆ¶æ§ä»¶ID
 	unsigned int fatherControlId = ReadUInt(lpControlInfo);
 	lpControlInfo += 4;
 
-	//×Ó¿Ø¼şÊıÄ¿
+	//å­æ§ä»¶æ•°ç›®
 	unsigned int childControlCount = ReadUInt(lpControlInfo);
 	lpControlInfo += 4;
 
@@ -405,15 +417,15 @@ void ESymbol::parseControlBasciProperty(unsigned char* lpControlInfo,EAppControl
 		//out_Property.mVec_childControl.push_back(tmpChildControlId);
 	}
 
-	//Î´ÖªÆ«ÒÆ
+	//æœªçŸ¥åç§»
 	unsigned int offset2 = ReadUInt(lpControlInfo);
 	lpControlInfo += offset2 + 4;
 
-	//±ê¼Ç
+	//æ ‡è®°
 	std::string m_tag = ReadStr(lpControlInfo);
 	lpControlInfo += qstrlen(lpControlInfo) + 1;
 
-	//Î´ÖªµÄÖµ
+	//æœªçŸ¥çš„å€¼
 	lpControlInfo += 12;
 
 	int dwEventCount = ReadInt(lpControlInfo);
@@ -436,7 +448,7 @@ bool ESymbol::loadGUIResource(unsigned int lpGUIStart, unsigned int infoSize)
 	tmpGuiBuf.resize(infoSize);
 	IDAWrapper::get_bytes(&tmpGuiBuf[0], infoSize, lpGUIStart);
 
-	//µ±Ç°½âÎöµØÖ·
+	//å½“å‰è§£æåœ°å€
 	unsigned char* lpCurrentParseAddr = &tmpGuiBuf[0];
 
 	std::vector<unsigned int> vec_WindowId;
@@ -448,7 +460,7 @@ bool ESymbol::loadGUIResource(unsigned int lpGUIStart, unsigned int infoSize)
 		lpCurrentParseAddr += 4;
 	}
 
-	//±àÒëÆ÷ÒÅÁôÖµ?
+	//ç¼–è¯‘å™¨é—ç•™å€¼?
 	for (unsigned int n = 0; n < dwTotalWindowCount; ++n) {
 		//uint32 unknowId = ReadUInt(lpCurrentParseAddr);
 		lpCurrentParseAddr += 4;
@@ -458,45 +470,45 @@ bool ESymbol::loadGUIResource(unsigned int lpGUIStart, unsigned int infoSize)
 	for (unsigned int nIndexWindow = 0; nIndexWindow < dwTotalWindowCount; ++nIndexWindow) {
 		unsigned char* lpWindowInfo = lpCurrentParseAddr;
 
-		//ÔİÊ±Î´Öª
+		//æš‚æ—¶æœªçŸ¥
 		uint32 unKnownFieldA = ReadUInt(lpWindowInfo);
 		lpWindowInfo += 4;
 		uint32 unKnownFieldB = ReadUInt(lpWindowInfo);
 		lpWindowInfo += 4;
 
-		//½ÓÏÂÀ´¸ú×ÅÁ½¸öCString,¶¼Îª¿Õ
+		//æ¥ä¸‹æ¥è·Ÿç€ä¸¤ä¸ªCString,éƒ½ä¸ºç©º
 		lpWindowInfo += 8;
 
-		//µ¥¸ö´°¿ÚÖĞµÄ¿Ø¼ş×Ü¸öÊı
+		//å•ä¸ªçª—å£ä¸­çš„æ§ä»¶æ€»ä¸ªæ•°
 		uint32 dwTotalControlCount = ReadUInt(lpWindowInfo);
 		lpWindowInfo += 4;
 
-		//µ¥¸ö´°¿ÚÖĞµÄ¿Ø¼ş×ÜÕ¼ÓÃ´óĞ¡
+		//å•ä¸ªçª—å£ä¸­çš„æ§ä»¶æ€»å ç”¨å¤§å°
 		uint32 dwTotalControlSize = ReadUInt(lpWindowInfo);
 		lpWindowInfo += 4;
 
-		//¿ªÊ¼½âÎö¿Ø¼ş
+		//å¼€å§‹è§£ææ§ä»¶
 		unsigned char* lpControlArray = lpWindowInfo;
 		{
-			//½âÎö¿Ø¼şID,ÀıÈç0x160612BC
+			//è§£ææ§ä»¶ID,ä¾‹å¦‚0x160612BC
 			std::vector<unsigned int> vec_ControlId;
 			for (unsigned int j = 0; j < dwTotalControlCount; ++j) {
 				vec_ControlId.push_back(ReadUInt(lpControlArray));
 				lpControlArray += 4;
 			}
 
-			//½âÎö¿Ø¼şÆ«ÒÆ
+			//è§£ææ§ä»¶åç§»
 			std::vector<unsigned int> vec_ControlOffset;
 			for (unsigned int j = 0; j < dwTotalControlCount; ++j) {
 				vec_ControlOffset.push_back(ReadUInt(lpControlArray));
 				lpControlArray += 4;
 			}
 
-			//½âÎö¿Ø¼şÊôĞÔ
+			//è§£ææ§ä»¶å±æ€§
 			for (unsigned int nIndexControl = 0; nIndexControl < dwTotalControlCount; ++nIndexControl) {
 				unsigned char* lpControlInfo = lpControlArray + vec_ControlOffset[nIndexControl];
 
-				//¿Ø¼şÕ¼ÓÃµÄ´óĞ¡
+				//æ§ä»¶å ç”¨çš„å¤§å°
 				int32 dwControlSize = ReadInt(lpControlInfo);
 				lpControlInfo += 4;
 
@@ -506,7 +518,7 @@ bool ESymbol::loadGUIResource(unsigned int lpGUIStart, unsigned int infoSize)
 				unsigned int dwControlTypeId = ReadUInt(lpControlInfo);
 				lpControlInfo += 4;
 
-				//¹Ì¶¨µÄ20¸ö¿Õ×Ö½Ú,±£ÁôÊ¹ÓÃ?
+				//å›ºå®šçš„20ä¸ªç©ºå­—èŠ‚,ä¿ç•™ä½¿ç”¨?
 				lpControlInfo += 20;
 
 				EAppControl* eControlInfo = EAppControlFactory::Instance().CreateEAppControl(dwControlTypeId);
@@ -516,20 +528,32 @@ bool ESymbol::loadGUIResource(unsigned int lpGUIStart, unsigned int infoSize)
 				eControlInfo->windowID = vec_WindowId[nIndexWindow];
 		
 				if (dwControlTypeId == 0x10001) {
-					eControlInfo->controlName = ReadStr(lpControlInfo);
+					{
+						qstring nameUtf8;
+						acp_utf8(&nameUtf8, ReadStr(lpControlInfo).c_str());
+						eControlInfo->controlName = nameUtf8.c_str();
+					}
 					lpControlInfo += strlen((const char*)lpControlInfo) + 1;
 					if (eControlInfo->controlName.empty()) {
-						sprintf_s(sprinfBuf, "´°¿Ú0x%08X", eControlInfo->windowID);
+						sprintf_s(sprinfBuf, "çª—å£0x%08X", eControlInfo->windowID);
 						eControlInfo->controlName = sprinfBuf;
 					}
 					parseControlBasciProperty(lpControlInfo, eControlInfo);
 				}
 				else if (krnln_IsMenuItemID(vec_ControlId[nIndexControl])) {
 					lpControlInfo += 14;
-					eControlInfo->controlName = ReadStr(lpControlInfo);
+					{
+						qstring nameUtf8;
+						acp_utf8(&nameUtf8, ReadStr(lpControlInfo).c_str());
+						eControlInfo->controlName = nameUtf8.c_str();
+					}
 				}
 				else {
-					eControlInfo->controlName = ReadStr(lpControlInfo);
+					{
+						qstring nameUtf8;
+						acp_utf8(&nameUtf8, ReadStr(lpControlInfo).c_str());
+						eControlInfo->controlName = nameUtf8.c_str();
+					}
 					lpControlInfo += qstrlen(lpControlInfo) + 1;
 					parseControlBasciProperty(lpControlInfo, eControlInfo);
 				}
@@ -597,7 +621,7 @@ bool ESymbol::handleFuncPushDefaultArg(unsigned int callAddr)
 
 bool ESymbol::scanEClassTable()
 {
-	//²»ĞÅÓĞÇø¶Î´óÓÚ0x1000000
+	//ä¸ä¿¡æœ‰åŒºæ®µå¤§äº0x1000000
 	qstring movClassTable;
 	movClassTable.sprnt("C7 03 ?? ?? ?? %02X", userCodeStartAddr >> 0x18);
 
@@ -608,7 +632,7 @@ bool ESymbol::scanEClassTable()
 	std::unordered_set<unsigned int> guessClassTableList;
 	while (true)
 	{
-		searchStartAddr = bin_search2(searchStartAddr, userCodeEndAddr, binPat, 0x0);
+		searchStartAddr = bin_search(searchStartAddr, userCodeEndAddr, binPat, 0x0);
 		if (searchStartAddr == BADADDR)
 		{
 			break;
@@ -618,7 +642,7 @@ bool ESymbol::scanEClassTable()
 		if (guessAddr < userCodeStartAddr) {
 			continue;
 		}
-		//ÅĞ¶ÏĞé±íÖĞÊÇ·ñº¬ÓĞ¿½±´º¯Êı,ÓĞ´ıÑéÖ¤
+		//åˆ¤æ–­è™šè¡¨ä¸­æ˜¯å¦å«æœ‰æ‹·è´å‡½æ•°,æœ‰å¾…éªŒè¯
 		auto copyHead = IDAWrapper::get_word(IDAWrapper::get_dword(guessAddr + 0x4));
 		if (copyHead != 0x6850) {
 			continue;
@@ -630,7 +654,7 @@ bool ESymbol::scanEClassTable()
 		return true;
 	}
 
-	//¸ù±¾ÎŞ·¨È·¶¨Ğé±íµÄ´óĞ¡,Òò´Ë¾¡¿ÉÄÜÀ©´ó
+	//æ ¹æœ¬æ— æ³•ç¡®å®šè™šè¡¨çš„å¤§å°,å› æ­¤å°½å¯èƒ½æ‰©å¤§
 	auto idati = (til_t*)get_idati();
 	for (std::unordered_set<unsigned int>::iterator it = guessClassTableList.begin(); it != guessClassTableList.end(); ++it) {
 		std::vector<unsigned int> vTable;
@@ -653,20 +677,30 @@ bool ESymbol::scanEClassTable()
 
 		qstring vTableName;
 		vTableName.sprnt("vtable_%a",*it);
-		tid_t idStruct = add_struc(-1, vTableName.c_str(),false);
-		struc_t* pStruct = get_struc(idStruct);
-		if (!pStruct) {
-			continue;
-		}
+		// IDA 9.x: æ—§ structs API (add_struc/add_struc_member) å·²ç§»é™¤, æ”¹ç”¨ til/udt API
+		udt_type_data_t udt;
+		udt.is_union = false;
+		udt.set_vftable();
+		tinfo_t dwordType(BTF_UINT32);
 		qstring fieldName;
+		std::set<qstring> usedNames;
 		for (unsigned int n = 0; n < vTable.size(); ++n) {
 			get_func_name(&fieldName, vTable[n]);
 			if (fieldName.empty()) {
 				fieldName.sprnt("sub_%a", vTable[n]);
 			}
-			add_struc_member(pStruct, fieldName.c_str(), 4 * n, dword_flag(), NULL, 4);
+			if (!usedNames.insert(fieldName).second) {
+				fieldName.sprnt("field_%X", 4 * n);
+			}
+			udt.push_back(udm_t(fieldName.c_str(), dwordType, 4 * n * (uint64)8));
 		}
-		tinfo_t info = create_typedef(vTableName.c_str());
+		tinfo_t info;
+		if (!info.create_udt(udt)) {
+			continue;
+		}
+		if (info.set_named_type(nullptr, vTableName.c_str(), NTF_TYPE) != TERR_OK) {
+			continue;
+		}
 		apply_tinfo(*it,info, TINFO_GUESSED);
 	}
 

--- a/E-Decompiler/ESymbol.h
+++ b/E-Decompiler/ESymbol.h
@@ -1,113 +1,113 @@
-#pragma once
+ï»¿#pragma once
 #include <string>
 #include <vector>
 #include <map>
 #include <set>
 #include "ELib.h"
 
-//Ò×ÓïÑÔ·ûºÅĞÅÏ¢
+//æ˜“è¯­è¨€ç¬¦å·ä¿¡æ¯
 
 struct EVENT_INFO
 {
-	unsigned int m_lpszName;       //ÊÂ¼şÃû³Æ
-	unsigned int m_lpszExplain;    //ÊÂ¼şÏêÏ¸½âÊÍ
-	unsigned int m_dwState;        //ÊÂ¼şÌØÊâ±êÖ¾
-	int  m_nArgCount;      //ÊÂ¼şµÄ²ÎÊıÊıÄ¿
-	unsigned int m_lpEventArgInfo; //²ÎÊı
+	unsigned int m_lpszName;       //äº‹ä»¶åç§°
+	unsigned int m_lpszExplain;    //äº‹ä»¶è¯¦ç»†è§£é‡Š
+	unsigned int m_dwState;        //äº‹ä»¶ç‰¹æ®Šæ ‡å¿—
+	int  m_nArgCount;      //äº‹ä»¶çš„å‚æ•°æ•°ç›®
+	unsigned int m_lpEventArgInfo; //å‚æ•°
 };
 
 #pragma pack(push,1)
 
 
 
-// ÓÃ×÷¶¨Òå´°¿Úµ¥ÔªÊôĞÔ
+// ç”¨ä½œå®šä¹‰çª—å£å•å…ƒå±æ€§
 struct UNIT_PROPERTY
 {
-	unsigned int m_lpszName;      //ÊôĞÔÃû³Æ
-	unsigned int m_lpszEGName;    //Ó¢ÎÄÃû³Æ
-	unsigned int m_lpszExplain;   //ÊôĞÔ½âÊÍ
-	short  m_shtType;       //ÊôĞÔµÄÊı¾İÀàĞÍ
-	unsigned short m_wState;        //ÊôĞÔµÄÌØÊâ±ê¼Ç
-	unsigned int m_lpszzPickStr;  //±¸Ñ¡ÎÄ±¾
+	unsigned int m_lpszName;      //å±æ€§åç§°
+	unsigned int m_lpszEGName;    //è‹±æ–‡åç§°
+	unsigned int m_lpszExplain;   //å±æ€§è§£é‡Š
+	short  m_shtType;       //å±æ€§çš„æ•°æ®ç±»å‹
+	unsigned short m_wState;        //å±æ€§çš„ç‰¹æ®Šæ ‡è®°
+	unsigned int m_lpszzPickStr;  //å¤‡é€‰æ–‡æœ¬
 };
 
-struct LIB_DATA_TYPE_INFO   //¿â¶¨ÒåÊı¾İÀàĞÍ½á¹¹
+struct LIB_DATA_TYPE_INFO   //åº“å®šä¹‰æ•°æ®ç±»å‹ç»“æ„
 {
-	unsigned int m_lpszName;     //Ãû³Æ
-	unsigned int m_lpszEGName;   //Ó¢ÎÄÃû³Æ,¿ÉÎª¿Õ
-	unsigned int m_szExplain;    //ÏêÏ¸½âÊÍ,¿ÉÎª¿Õ
-	int  m_nCmdCount;    //±¾Êı¾İÀàĞÍ³ÉÔ±·½·¨µÄÊıÄ¿(¿ÉÎª0)
-	unsigned int m_lpnCmdsIndex; //Ö¸ÏòËùÓĞ³ÉÔ±·½·¨ÃüÁîÔÚÖ§³Ö¿âÃüÁî±íÖĞµÄË÷ÒıÖµÖ¸Õë,±àÒëºóÊı¾İ±»Ä¨³ı
-	unsigned int m_dwState;      //Êı¾İÀàĞÍµÄÌØÊâÊôĞÔ
+	unsigned int m_lpszName;     //åç§°
+	unsigned int m_lpszEGName;   //è‹±æ–‡åç§°,å¯ä¸ºç©º
+	unsigned int m_szExplain;    //è¯¦ç»†è§£é‡Š,å¯ä¸ºç©º
+	int  m_nCmdCount;    //æœ¬æ•°æ®ç±»å‹æˆå‘˜æ–¹æ³•çš„æ•°ç›®(å¯ä¸º0)
+	unsigned int m_lpnCmdsIndex; //æŒ‡å‘æ‰€æœ‰æˆå‘˜æ–¹æ³•å‘½ä»¤åœ¨æ”¯æŒåº“å‘½ä»¤è¡¨ä¸­çš„ç´¢å¼•å€¼æŒ‡é’ˆ,ç¼–è¯‘åæ•°æ®è¢«æŠ¹é™¤
+	unsigned int m_dwState;      //æ•°æ®ç±»å‹çš„ç‰¹æ®Šå±æ€§
 
 	 ////////////////////////////////////////////
-	// ÒÔÏÂ³ÉÔ±Ö»ÓĞÔÚÎª´°¿Úµ¥Ôª¡¢²Ëµ¥Ê±²ÅÓĞĞ§¡£
+	// ä»¥ä¸‹æˆå‘˜åªæœ‰åœ¨ä¸ºçª—å£å•å…ƒã€èœå•æ—¶æ‰æœ‰æ•ˆã€‚
 
-	unsigned int m_dwUnitBmpID;     //Ö¸¶¨ÔÚÖ§³Ö¿âÖĞµÄµ¥ÔªÍ¼Ïñ×ÊÔ´ID
-	int  m_nEventCount;     //±¾µ¥ÔªµÄÊÂ¼şÊıÄ¿
-	unsigned int m_lpEventBegin;    //Ö¸Ïòµ¥ÔªµÄËùÓĞÊÂ¼şµÄÖ¸Õë,EVENT_INFO,±àÒëºóÊı¾İ±»Ä¨³ı
-	int m_nPropertyCount;   //±¾µ¥ÔªµÄÊôĞÔÊıÄ¿
-	unsigned int m_lpPropertyBegin; //Ö¸Ïòµ¥ÔªµÄËùÓĞÊôĞÔµÄÖ¸Õë,UNIT_PROPERTY
+	unsigned int m_dwUnitBmpID;     //æŒ‡å®šåœ¨æ”¯æŒåº“ä¸­çš„å•å…ƒå›¾åƒèµ„æºID
+	int  m_nEventCount;     //æœ¬å•å…ƒçš„äº‹ä»¶æ•°ç›®
+	unsigned int m_lpEventBegin;    //æŒ‡å‘å•å…ƒçš„æ‰€æœ‰äº‹ä»¶çš„æŒ‡é’ˆ,EVENT_INFO,ç¼–è¯‘åæ•°æ®è¢«æŠ¹é™¤
+	int m_nPropertyCount;   //æœ¬å•å…ƒçš„å±æ€§æ•°ç›®
+	unsigned int m_lpPropertyBegin; //æŒ‡å‘å•å…ƒçš„æ‰€æœ‰å±æ€§çš„æŒ‡é’ˆ,UNIT_PROPERTY
 
-	unsigned int m_lpfnGetInterface; //ÓÃ×÷Ìá¹©±¾´°¿Úµ¥ÔªµÄËùÓĞ½Ó¿Ú¡£
+	unsigned int m_lpfnGetInterface; //ç”¨ä½œæä¾›æœ¬çª—å£å•å…ƒçš„æ‰€æœ‰æ¥å£ã€‚
 
 	////////////////////////////////////////////
-	// ÒÔÏÂ³ÉÔ±Ö»ÓĞÔÚ²»Îª´°¿Úµ¥Ôª¡¢²Ëµ¥Ê±²ÅÓĞĞ§¡£
+	// ä»¥ä¸‹æˆå‘˜åªæœ‰åœ¨ä¸ä¸ºçª—å£å•å…ƒã€èœå•æ—¶æ‰æœ‰æ•ˆã€‚
 
-	int m_nElementCount;    //±¾Êı¾İÀàĞÍÖĞ×Ó³ÉÔ±µÄÊıÄ¿(¿ÉÎª0)
-	unsigned int m_lpElementBegin;   //Ö¸Ïò×Ó³ÉÔ±Êı×éµÄÊ×µØÖ·,LIB_DATA_TYPE_ELEMENT
+	int m_nElementCount;    //æœ¬æ•°æ®ç±»å‹ä¸­å­æˆå‘˜çš„æ•°ç›®(å¯ä¸º0)
+	unsigned int m_lpElementBegin;   //æŒ‡å‘å­æˆå‘˜æ•°ç»„çš„é¦–åœ°å€,LIB_DATA_TYPE_ELEMENT
 };
 
 struct LIB_INFO
 {
-	unsigned int m_dwLibFormatVer;    //Ö§³Ö¿â¸ñÊ½°æ±¾ºÅ,Ó¦¸ÃÎª0x1312D65
-	unsigned int m_lpGuid;            //¶ÔÓ¦Ö§³Ö¿âµÄGUIDÖ¸Õë¡£
-	int  m_nMajorVersion;     //Ö§³Ö¿âµÄÖ÷°æ±¾ºÅ£¬±ØĞë´óÓÚ0¡£
-	int  m_nMinorVersion;     //Ö§³Ö¿âµÄ´Î°æ±¾ºÅ¡£
-	int  m_nBuildNumber;      //¹¹½¨°æ±¾ºÅ
-	int  m_nRqSysMajorVer;    //ËùĞèÒªÒ×ÓïÑÔÏµÍ³µÄÖ÷°æ±¾ºÅ
-	int  m_nRqSysMinorVer;    //ËùĞèÒªÒ×ÓïÑÔÏµÍ³µÄ´Î°æ±¾ºÅ
-	int  m_nRqSysKrnlLibMajorVer;   //ËùĞèÒªµÄÏµÍ³ºËĞÄÖ§³Ö¿âµÄÖ÷°æ±¾ºÅ
-	int  m_nRqSysKrnlLibMinorVer;   //ËùĞèÒªµÄÏµÍ³ºËĞÄÖ§³Ö¿âµÄ´Î°æ±¾ºÅ
-	unsigned int m_lpName;            //Ö§³Ö¿âÃû³ÆÖ¸Õë
-	int  m_nLanguage;         //Ö§³Ö¿âËùÖ§³ÖµÄÓïÑÔ,Ó¦¸ÃÊÇ1
-	unsigned int m_lpExplain;         //Ö§³Ö¿â½âÊÍÄÚÈİÖ¸Õë,¿ÉÎª¿Õ
-	unsigned int m_dwState;           //Ö§³Ö¿âÌØÊâ×´Ì¬ËµÃ÷
-	unsigned int m_lpszAuthor;        //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszZipCode;       //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszAddress;       //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszPhone;         //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszFax;           //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszEmail;         //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszHomePage;      //×÷ÕßÏà¹ØĞÅÏ¢
-	unsigned int m_lpszOther;         //×÷ÕßÏà¹ØĞÅÏ¢
+	unsigned int m_dwLibFormatVer;    //æ”¯æŒåº“æ ¼å¼ç‰ˆæœ¬å·,åº”è¯¥ä¸º0x1312D65
+	unsigned int m_lpGuid;            //å¯¹åº”æ”¯æŒåº“çš„GUIDæŒ‡é’ˆã€‚
+	int  m_nMajorVersion;     //æ”¯æŒåº“çš„ä¸»ç‰ˆæœ¬å·ï¼Œå¿…é¡»å¤§äº0ã€‚
+	int  m_nMinorVersion;     //æ”¯æŒåº“çš„æ¬¡ç‰ˆæœ¬å·ã€‚
+	int  m_nBuildNumber;      //æ„å»ºç‰ˆæœ¬å·
+	int  m_nRqSysMajorVer;    //æ‰€éœ€è¦æ˜“è¯­è¨€ç³»ç»Ÿçš„ä¸»ç‰ˆæœ¬å·
+	int  m_nRqSysMinorVer;    //æ‰€éœ€è¦æ˜“è¯­è¨€ç³»ç»Ÿçš„æ¬¡ç‰ˆæœ¬å·
+	int  m_nRqSysKrnlLibMajorVer;   //æ‰€éœ€è¦çš„ç³»ç»Ÿæ ¸å¿ƒæ”¯æŒåº“çš„ä¸»ç‰ˆæœ¬å·
+	int  m_nRqSysKrnlLibMinorVer;   //æ‰€éœ€è¦çš„ç³»ç»Ÿæ ¸å¿ƒæ”¯æŒåº“çš„æ¬¡ç‰ˆæœ¬å·
+	unsigned int m_lpName;            //æ”¯æŒåº“åç§°æŒ‡é’ˆ
+	int  m_nLanguage;         //æ”¯æŒåº“æ‰€æ”¯æŒçš„è¯­è¨€,åº”è¯¥æ˜¯1
+	unsigned int m_lpExplain;         //æ”¯æŒåº“è§£é‡Šå†…å®¹æŒ‡é’ˆ,å¯ä¸ºç©º
+	unsigned int m_dwState;           //æ”¯æŒåº“ç‰¹æ®ŠçŠ¶æ€è¯´æ˜
+	unsigned int m_lpszAuthor;        //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszZipCode;       //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszAddress;       //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszPhone;         //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszFax;           //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszEmail;         //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszHomePage;      //ä½œè€…ç›¸å…³ä¿¡æ¯
+	unsigned int m_lpszOther;         //ä½œè€…ç›¸å…³ä¿¡æ¯
 
 //////////////////
-	int m_nDataTypeCount;     //Ö§³Ö¿âÈ«²¿µÄÊı¾İÀàĞÍ¸öÊı
-	unsigned int m_lpDataType;        //Ö¸Ïò³ÌĞòÓÃµ½µÄÊı¾İÀàĞÍĞÅÏ¢µÄÖ¸Õë,LIB_DATA_TYPE_INFO
+	int m_nDataTypeCount;     //æ”¯æŒåº“å…¨éƒ¨çš„æ•°æ®ç±»å‹ä¸ªæ•°
+	unsigned int m_lpDataType;        //æŒ‡å‘ç¨‹åºç”¨åˆ°çš„æ•°æ®ç±»å‹ä¿¡æ¯çš„æŒ‡é’ˆ,LIB_DATA_TYPE_INFO
 
-	int m_nCategoryCount;     //È«¾ÖÃüÁîÀà±ğÊıÄ¿
-	unsigned int m_lpszzCategory;     //È«¾ÖÃüÁîÀà±ğËµÃ÷±í£¬Ã¿ÏîÎªÒ»×Ö·û´®£¬Ç°ËÄÎ»Êı×Ö±íÊ¾Í¼ÏóË÷ÒıºÅ£¨´Ó1¿ªÊ¼£¬0±íÊ¾ÎŞ£©¡£
-								// ¼õÒ»ºóµÄÖµÎªÖ¸ÏòÖ§³Ö¿âÖĞÃûÎª"LIB_BITMAP"µÄBITMAP×ÊÔ´ÖĞÄ³Ò»²¿·Ö16X13Î»Í¼µÄË÷Òı
+	int m_nCategoryCount;     //å…¨å±€å‘½ä»¤ç±»åˆ«æ•°ç›®
+	unsigned int m_lpszzCategory;     //å…¨å±€å‘½ä»¤ç±»åˆ«è¯´æ˜è¡¨ï¼Œæ¯é¡¹ä¸ºä¸€å­—ç¬¦ä¸²ï¼Œå‰å››ä½æ•°å­—è¡¨ç¤ºå›¾è±¡ç´¢å¼•å·ï¼ˆä»1å¼€å§‹ï¼Œ0è¡¨ç¤ºæ— ï¼‰ã€‚
+								// å‡ä¸€åçš„å€¼ä¸ºæŒ‡å‘æ”¯æŒåº“ä¸­åä¸º"LIB_BITMAP"çš„BITMAPèµ„æºä¸­æŸä¸€éƒ¨åˆ†16X13ä½å›¾çš„ç´¢å¼•
 
-	int m_nCmdCount;          //±¾¿âÖĞÌá¹©µÄËùÓĞÃüÁî(È«¾ÖÃüÁî¼°¶ÔÏó·½·¨)µÄÊıÄ¿(ÈçÎŞÔòÎª0)¡£
-	unsigned int m_lpBeginCmdInfo;    //Ö¸ÏòËùÓĞÃüÁî¼°·½·¨µÄ¶¨ÒåĞÅÏ¢Êı×é(Èçm_nCmdCountÎª0,ÔòÎªNULL),CMD_INFO
-	unsigned int m_lpCmdsFunc;        //Ö¸ÏòÃ¿¸öÃüÁîµÄÊµÏÖ´úÂëÊ×µØÖ·£¬(Èçm_nCmdCountÎª0, ÔòÎªNULL)¡£
+	int m_nCmdCount;          //æœ¬åº“ä¸­æä¾›çš„æ‰€æœ‰å‘½ä»¤(å…¨å±€å‘½ä»¤åŠå¯¹è±¡æ–¹æ³•)çš„æ•°ç›®(å¦‚æ— åˆ™ä¸º0)ã€‚
+	unsigned int m_lpBeginCmdInfo;    //æŒ‡å‘æ‰€æœ‰å‘½ä»¤åŠæ–¹æ³•çš„å®šä¹‰ä¿¡æ¯æ•°ç»„(å¦‚m_nCmdCountä¸º0,åˆ™ä¸ºNULL),CMD_INFO
+	unsigned int m_lpCmdsFunc;        //æŒ‡å‘æ¯ä¸ªå‘½ä»¤çš„å®ç°ä»£ç é¦–åœ°å€ï¼Œ(å¦‚m_nCmdCountä¸º0, åˆ™ä¸ºNULL)ã€‚
 
-	unsigned int m_lpfnRunAddInFn;    //¿ÉÎªNULL£¬ÓÃ×÷ÎªÒ×ÓïÑÔIDEÌá¹©¸½¼Ó¹¦ÄÜ
-	unsigned int m_szzAddInFnInfo;    //ÓĞ¹ØAddIn¹¦ÄÜµÄËµÃ÷£¬Á½¸ö×Ö·û´®ËµÃ÷Ò»¸ö¹¦ÄÜ
+	unsigned int m_lpfnRunAddInFn;    //å¯ä¸ºNULLï¼Œç”¨ä½œä¸ºæ˜“è¯­è¨€IDEæä¾›é™„åŠ åŠŸèƒ½
+	unsigned int m_szzAddInFnInfo;    //æœ‰å…³AddInåŠŸèƒ½çš„è¯´æ˜ï¼Œä¸¤ä¸ªå­—ç¬¦ä¸²è¯´æ˜ä¸€ä¸ªåŠŸèƒ½
 
-	unsigned int m_lpfnNotify;        //²»ÄÜÎªNULL£¬Ìá¹©½ÓÊÕÀ´×ÔÒ×ÓïÑÔIDE»òÔËĞĞ»·¾³Í¨ÖªĞÅÏ¢µÄº¯Êı¡£
+	unsigned int m_lpfnNotify;        //ä¸èƒ½ä¸ºNULLï¼Œæä¾›æ¥æ”¶æ¥è‡ªæ˜“è¯­è¨€IDEæˆ–è¿è¡Œç¯å¢ƒé€šçŸ¥ä¿¡æ¯çš„å‡½æ•°ã€‚
 
-	// ³¬¼¶Ä£°åÔİÊ±±£Áô²»ÓÃ¡£
-	unsigned int m_lpfnSuperTemplate;       //Îª¿Õ
-	unsigned int m_lpszzSuperTemplateInfo;  //Îª¿Õ
+	// è¶…çº§æ¨¡æ¿æš‚æ—¶ä¿ç•™ä¸ç”¨ã€‚
+	unsigned int m_lpfnSuperTemplate;       //ä¸ºç©º
+	unsigned int m_lpszzSuperTemplateInfo;  //ä¸ºç©º
 
-	// ±¾¿â¶¨ÒåµÄËùÓĞ³£Á¿¡£
-	int m_nLibConstCount;   //³£Á¿Êı¾İ
-	unsigned int m_lpLibConst;      //Ö¸Ïò³£Á¿¶¨ÒåÊı×éµÄÖ¸Õë
+	// æœ¬åº“å®šä¹‰çš„æ‰€æœ‰å¸¸é‡ã€‚
+	int m_nLibConstCount;   //å¸¸é‡æ•°æ®
+	unsigned int m_lpLibConst;      //æŒ‡å‘å¸¸é‡å®šä¹‰æ•°ç»„çš„æŒ‡é’ˆ
 
-	unsigned int m_lpszzDependFiles; //±¾¿âÕı³£ÔËĞĞËùĞèÒªÒÀÀµµÄÆäËûÎÄ¼ş£¬ÔÚÖÆ×÷°²×°Èí¼şÊ±½«»á×Ô¶¯´øÉÏÕâĞ©ÎÄ¼ş,¿ÉÎª¿Õ
+	unsigned int m_lpszzDependFiles; //æœ¬åº“æ­£å¸¸è¿è¡Œæ‰€éœ€è¦ä¾èµ–çš„å…¶ä»–æ–‡ä»¶ï¼Œåœ¨åˆ¶ä½œå®‰è£…è½¯ä»¶æ—¶å°†ä¼šè‡ªåŠ¨å¸¦ä¸Šè¿™äº›æ–‡ä»¶,å¯ä¸ºç©º
 };
 
 #pragma pack(pop)
@@ -116,90 +116,90 @@ struct LIB_INFO
 
 struct eSymbol_EDataTypeInfo
 {
-	std::string m_Name;  //Êı¾İÀàĞÍÃû³Æ
+	std::string m_Name;  //æ•°æ®ç±»å‹åç§°
 };
 
 struct eSymbol_ELibInfo
 {
-	std::string m_Name;         //Ö§³Ö¿âÃû³Æ
-	std::string m_Guid;         //Ö§³Ö¿âµÄGUID
-	int  m_nMajorVersion;       //Ö§³Ö¿âµÄÖ÷°æ±¾ºÅ£¬±ØĞë´óÓÚ0¡£
-	int  m_nMinorVersion;       //Ö§³Ö¿âµÄ´Î°æ±¾ºÅ¡£
+	std::string m_Name;         //æ”¯æŒåº“åç§°
+	std::string m_Guid;         //æ”¯æŒåº“çš„GUID
+	int  m_nMajorVersion;       //æ”¯æŒåº“çš„ä¸»ç‰ˆæœ¬å·ï¼Œå¿…é¡»å¤§äº0ã€‚
+	int  m_nMinorVersion;       //æ”¯æŒåº“çš„æ¬¡ç‰ˆæœ¬å·ã€‚
 
-	std::vector<eSymbol_EDataTypeInfo> mVec_DataTypeInfo;      //Êı¾İÀàĞÍĞÅÏ¢
+	std::vector<eSymbol_EDataTypeInfo> mVec_DataTypeInfo;      //æ•°æ®ç±»å‹ä¿¡æ¯
 };
 
 struct eSymbol_KrnlCall
 {
-	unsigned int krnl_MReportError;               //´íÎó»Øµ÷
-	unsigned int krnl_MCallDllCmd;                //DLLÃüÁî
-	unsigned int krnl_MCallLibCmd;                //Èı·½Ö§³Ö¿âÃüÁî
-	unsigned int krnl_MCallKrnlLibCmd;            //ºËĞÄÖ§³Ö¿âÃüÁî
-	unsigned int krnl_MReadProperty;              //¶ÁÈ¡×é¼şÊôĞÔ
-	unsigned int krnl_MWriteProperty;             //ÉèÖÃ×é¼şÊôĞÔ
-	unsigned int krnl_MMalloc;                    //·ÖÅäÄÚ´æ
-	unsigned int krnl_MRealloc;                   //ÖØĞÂ·ÖÅäÄÚ´æ
-	unsigned int krnl_MFree;                      //ÊÍ·ÅÄÚ´æ
-	unsigned int krnl_MExitProcess;               //½áÊø
-	unsigned int krnl_MMessageLoop;               //´°¿ÚÏûÏ¢Ñ­»·
-	unsigned int krnl_MLoadBeginWin;              //ÔØÈëÆô¶¯´°¿Ú
-	unsigned int krnl_MOtherHelp;                 //¸¨Öú¹¦ÄÜ
+	unsigned int krnl_MReportError;               //é”™è¯¯å›è°ƒ
+	unsigned int krnl_MCallDllCmd;                //DLLå‘½ä»¤
+	unsigned int krnl_MCallLibCmd;                //ä¸‰æ–¹æ”¯æŒåº“å‘½ä»¤
+	unsigned int krnl_MCallKrnlLibCmd;            //æ ¸å¿ƒæ”¯æŒåº“å‘½ä»¤
+	unsigned int krnl_MReadProperty;              //è¯»å–ç»„ä»¶å±æ€§
+	unsigned int krnl_MWriteProperty;             //è®¾ç½®ç»„ä»¶å±æ€§
+	unsigned int krnl_MMalloc;                    //åˆ†é…å†…å­˜
+	unsigned int krnl_MRealloc;                   //é‡æ–°åˆ†é…å†…å­˜
+	unsigned int krnl_MFree;                      //é‡Šæ”¾å†…å­˜
+	unsigned int krnl_MExitProcess;               //ç»“æŸ
+	unsigned int krnl_MMessageLoop;               //çª—å£æ¶ˆæ¯å¾ªç¯
+	unsigned int krnl_MLoadBeginWin;              //è½½å…¥å¯åŠ¨çª—å£
+	unsigned int krnl_MOtherHelp;                 //è¾…åŠ©åŠŸèƒ½
 };
 
 struct eSymbol_KrnlJmp
 {
-	unsigned int Jmp_MReportError;               //´íÎó»Øµ÷
-	unsigned int Jmp_MCallDllCmd;                //DLLÃüÁî
-	unsigned int Jmp_MCallLibCmd;                //Èı·½Ö§³Ö¿âÃüÁî
-	unsigned int Jmp_MCallKrnlLibCmd;            //ºËĞÄÖ§³Ö¿âÃüÁî
-	unsigned int Jmp_MReadProperty;              //¶ÁÈ¡×é¼şÊôĞÔ
-	unsigned int Jmp_MWriteProperty;             //ÉèÖÃ×é¼şÊôĞÔ
-	unsigned int Jmp_MMalloc;                    //·ÖÅäÄÚ´æ
-	unsigned int Jmp_MRealloc;                   //ÖØĞÂ·ÖÅäÄÚ´æ
-	unsigned int Jmp_MFree;                      //ÊÍ·ÅÄÚ´æ
-	unsigned int Jmp_MExitProcess;               //½áÊø
-	unsigned int Jmp_MMessageLoop;               //´°¿ÚÏûÏ¢Ñ­»·
-	unsigned int Jmp_MLoadBeginWin;              //ÔØÈëÆô¶¯´°¿Ú
-	unsigned int Jmp_MOtherHelp;                 //¸¨Öú¹¦ÄÜ
+	unsigned int Jmp_MReportError;               //é”™è¯¯å›è°ƒ
+	unsigned int Jmp_MCallDllCmd;                //DLLå‘½ä»¤
+	unsigned int Jmp_MCallLibCmd;                //ä¸‰æ–¹æ”¯æŒåº“å‘½ä»¤
+	unsigned int Jmp_MCallKrnlLibCmd;            //æ ¸å¿ƒæ”¯æŒåº“å‘½ä»¤
+	unsigned int Jmp_MReadProperty;              //è¯»å–ç»„ä»¶å±æ€§
+	unsigned int Jmp_MWriteProperty;             //è®¾ç½®ç»„ä»¶å±æ€§
+	unsigned int Jmp_MMalloc;                    //åˆ†é…å†…å­˜
+	unsigned int Jmp_MRealloc;                   //é‡æ–°åˆ†é…å†…å­˜
+	unsigned int Jmp_MFree;                      //é‡Šæ”¾å†…å­˜
+	unsigned int Jmp_MExitProcess;               //ç»“æŸ
+	unsigned int Jmp_MMessageLoop;               //çª—å£æ¶ˆæ¯å¾ªç¯
+	unsigned int Jmp_MLoadBeginWin;              //è½½å…¥å¯åŠ¨çª—å£
+	unsigned int Jmp_MOtherHelp;                 //è¾…åŠ©åŠŸèƒ½
 };
 
 struct EComHead
 {
-	unsigned int dwMagic;  //Î´Öª,Öµ¹Ì¶¨Îª3
-	unsigned int szNone2;  //Î´Öª,Öµ¹Ì¶¨Îª0
-	unsigned int szNone3;  //Î´Öª,ºÃÏñÊÇ¸öËæ»úÊı,ĞŞ¸Ä²»Ó°Ïì³ÌĞò
-	unsigned int lpStartCode;   //ÆğÊ¼ÓÃ»§´úÂëµØÖ·,²»¿ÉĞŞ¸Ä
-	unsigned int lpEString;     //×Ö·û´®×ÊÔ´,Èç¹ûÃ»ÓĞ×Ö·û´®×ÊÔ´,ÔòÎª0
-	unsigned int dwEStringSize; //×Ö·û´®×ÊÔ´´óĞ¡,Èç¹ûÃ»ÓĞ×Ö·û´®×ÊÔ´,ÔòÎª0
-	unsigned int lpEWindow;     //´´½¨×é¼şĞÅÏ¢
-	unsigned int dwEWindowSize; //´´½¨×é¼şĞÅÏ¢´óĞ¡
-	unsigned int dwLibNum;      //Ö§³Ö¿âÊıÁ¿
-	unsigned int lpLibEntry;    //Ö§³Ö¿âĞÅÏ¢Èë¿Ú
-	unsigned int dwApiCount;    //ApiÊıÁ¿
-	unsigned int lpModuleName;  //Ö¸ÏòÄ£¿éÃû³Æ
-	unsigned int lpApiName;     //Ö¸ÏòApiÃû³Æ
+	unsigned int dwMagic;  //æœªçŸ¥,å€¼å›ºå®šä¸º3
+	unsigned int szNone2;  //æœªçŸ¥,å€¼å›ºå®šä¸º0
+	unsigned int szNone3;  //æœªçŸ¥,å¥½åƒæ˜¯ä¸ªéšæœºæ•°,ä¿®æ”¹ä¸å½±å“ç¨‹åº
+	unsigned int lpStartCode;   //èµ·å§‹ç”¨æˆ·ä»£ç åœ°å€,ä¸å¯ä¿®æ”¹
+	unsigned int lpEString;     //å­—ç¬¦ä¸²èµ„æº,å¦‚æœæ²¡æœ‰å­—ç¬¦ä¸²èµ„æº,åˆ™ä¸º0
+	unsigned int dwEStringSize; //å­—ç¬¦ä¸²èµ„æºå¤§å°,å¦‚æœæ²¡æœ‰å­—ç¬¦ä¸²èµ„æº,åˆ™ä¸º0
+	unsigned int lpEWindow;     //åˆ›å»ºç»„ä»¶ä¿¡æ¯
+	unsigned int dwEWindowSize; //åˆ›å»ºç»„ä»¶ä¿¡æ¯å¤§å°
+	unsigned int dwLibNum;      //æ”¯æŒåº“æ•°é‡
+	unsigned int lpLibEntry;    //æ”¯æŒåº“ä¿¡æ¯å…¥å£
+	unsigned int dwApiCount;    //Apiæ•°é‡
+	unsigned int lpModuleName;  //æŒ‡å‘æ¨¡å—åç§°
+	unsigned int lpApiName;     //æŒ‡å‘Apiåç§°
 };
 
 enum eSymbolFuncType
 {
 	eFunc_Unknown = 0x0,
-	//Ò×ÓïÑÔ¿âº¯Êı
+	//æ˜“è¯­è¨€åº“å‡½æ•°
 	eFunc_KrnlLibFunc,
-	//¶ÁÈ¡×é¼şÊôĞÔ
+	//è¯»å–ç»„ä»¶å±æ€§
 	eFunc_KrnlReadProerty,
-	//ÉèÖÃ×é¼şÊôĞÔ
+	//è®¾ç½®ç»„ä»¶å±æ€§
 	eFunc_KrnlWriteProperty,
-	//µ÷ÓÃDLLÃüÁî
+	//è°ƒç”¨DLLå‘½ä»¤
 	eFunc_KrnlDllCmd,
-	//´íÎó»Øµ÷
+	//é”™è¯¯å›è°ƒ
 	eFunc_KrnlReportError,
-	//ÊÍ·ÅÄÚ´æ
+	//é‡Šæ”¾å†…å­˜
 	eFunc_KrnlFreeMem,
-	//ÎÄ±¾Ïà¼Ó
+	//æ–‡æœ¬ç›¸åŠ 
 	eFunc_Strcat,
-	//Á¬ĞøÊ¡ÂÔ²ÎÊı
+	//è¿ç»­çœç•¥å‚æ•°
 	eFunc_PushDefaultArg,
-	//¼ÆËã¶àÎ¬Êı×éÏÂ±ê
+	//è®¡ç®—å¤šç»´æ•°ç»„ä¸‹æ ‡
 	eFunc_CalMultiArrayIndex,
 };
 
@@ -232,63 +232,63 @@ public:
 	ESymbol();
 	~ESymbol();
 public:
-	//¼ÓÔØÒ×ÓïÑÔ¾²Ì¬±àÒë·ûºÅ
+	//åŠ è½½æ˜“è¯­è¨€é™æ€ç¼–è¯‘ç¬¦å·
 	bool LoadEStaticSymbol(unsigned int eHeadAddr, EComHead* eHead);
 
-	//»ñÈ¡º¯Êı·ûºÅÀàĞÍ
+	//è·å–å‡½æ•°ç¬¦å·ç±»å‹
 	eSymbolFuncType GetFuncSymbolType(unsigned int addr);
-	//Í¨¹ı´°¿ÚIDºÍ¿Ø¼şIDË÷Òıµ½¿Ø¼ş
+	//é€šè¿‡çª—å£IDå’Œæ§ä»¶IDç´¢å¼•åˆ°æ§ä»¶
 	EAppControl* GetEAppControl(unsigned int windowID,unsigned int controID);
 private:
-	//¼ÓÔØÖ§³Ö¿âĞÅÏ¢
+	//åŠ è½½æ”¯æŒåº“ä¿¡æ¯
 	bool loadELibInfomation(unsigned int lpLibStartAddr, unsigned int dwLibCount);
-	//É¨Ãè²¢Ê¶±ğÖ§³Ö¿âº¯Êı
+	//æ‰«æå¹¶è¯†åˆ«æ”¯æŒåº“å‡½æ•°
 	bool scanELibFunction(unsigned int lpLibStartAddr, unsigned int dwLibCount);
-	//É¨Ãè²¢Ê¶±ğÒ×ÓïÑÔ»ù´¡ÃüÁî
+	//æ‰«æå¹¶è¯†åˆ«æ˜“è¯­è¨€åŸºç¡€å‘½ä»¤
 	bool scanBasicFunction();
-	//¼ÓÔØÒ×ÓïÑÔºËĞÄº¯Êı
+	//åŠ è½½æ˜“è¯­è¨€æ ¸å¿ƒå‡½æ•°
 	bool loadKrnlInterface(unsigned int lpKrnlEntry);
-	//¼ÓÔØ½çÃæ×ÊÔ´ĞÅÏ¢
+	//åŠ è½½ç•Œé¢èµ„æºä¿¡æ¯
 	bool loadGUIResource(unsigned int lpGUIStart, unsigned int infoSize);
-	//¼ÓÔØÓÃ»§µ¼Èë±í
+	//åŠ è½½ç”¨æˆ·å¯¼å…¥è¡¨
 	bool loadUserImports(unsigned int dwApiCount, unsigned int lpModuleName, unsigned int lpApiName);
-	//´¦ÀíÁ¬ĞøÊ¡ÂÔ²ÎÊı
+	//å¤„ç†è¿ç»­çœç•¥å‚æ•°
 	bool handleFuncPushDefaultArg(unsigned int callAddr);
-	//É¨ÃèÒ×ÓïÑÔÀàĞé±í
+	//æ‰«ææ˜“è¯­è¨€ç±»è™šè¡¨
 	bool scanEClassTable();
-	//½âÎö¿Ø¼ş»ù´¡ÊôĞÔ
+	//è§£ææ§ä»¶åŸºç¡€å±æ€§
 	void parseControlBasciProperty(unsigned char* lpControlInfo, EAppControl* outControl);
-	//¸ù¾İ²Ëµ¥µÄÀàĞÍIDÀ´µÃµ½Ãû³Æ,0x10001 -> ´°¿Ú
+	//æ ¹æ®èœå•çš„ç±»å‹IDæ¥å¾—åˆ°åç§°,0x10001 -> çª—å£
 	std::string getControlTypeName(unsigned int typeId);
 	
 	bool registerKrnlJmpAddr(unsigned int callAddr, unsigned int setAddr);
 
-	//ÉèÖÃ¿Ø¼şµÄÊÂ¼şÃû³Æ
+	//è®¾ç½®æ§ä»¶çš„äº‹ä»¶åç§°
 	void setGuiEventName();
-	//ÇåÀí¿Ø¼ş
+	//æ¸…ç†æ§ä»¶
 	void clearControlData();
 public:
-	//Ö§³Ö¿âĞÅÏ¢
+	//æ”¯æŒåº“ä¿¡æ¯
 	std::vector<eSymbol_ELibInfo> vec_ELibInfo;
-	//ºËĞÄº¯Êı
+	//æ ¸å¿ƒå‡½æ•°
 	eSymbol_KrnlCall krnlCall;
 	eSymbol_KrnlJmp krnlJmp;
-	//ÓÃ»§ÆğÊ¼µØÖ·
+	//ç”¨æˆ·èµ·å§‹åœ°å€
 	unsigned int userCodeStartAddr;
-	//ÓÃ»§½áÊøµØÖ·,Ä¿Ç°ÔİÊ±»¹Ã»ÓĞÊ²Ã´ºÃ°ì·¨»ñÈ¡Õâ¸öµØÖ·,Èç¹ûÓĞºÃµÄÏë·¨»¶Ó­Ìáissue
+	//ç”¨æˆ·ç»“æŸåœ°å€,ç›®å‰æš‚æ—¶è¿˜æ²¡æœ‰ä»€ä¹ˆå¥½åŠæ³•è·å–è¿™ä¸ªåœ°å€,å¦‚æœæœ‰å¥½çš„æƒ³æ³•æ¬¢è¿æissue
 	unsigned int userCodeEndAddr;
 
-	//µ¼Èë±í,keyÊÇË÷Òı,valueÊÇµ¼ÈëĞÅÏ¢
+	//å¯¼å…¥è¡¨,keyæ˜¯ç´¢å¼•,valueæ˜¯å¯¼å…¥ä¿¡æ¯
 	std::vector<eSymbol_ImportsApi> importsApiList;
-	//ÁÙÊ±µ¼Èë±í
+	//ä¸´æ—¶å¯¼å…¥è¡¨
 	std::vector<std::string> tmpImportsApiList;
 
-	//´æ´¢ËùÓĞµÄ¿Ø¼şĞÅÏ¢
+	//å­˜å‚¨æ‰€æœ‰çš„æ§ä»¶ä¿¡æ¯
 	std::vector<EAppControl*> allControlList;
 private:
 
-	//±ê¼Çº¯ÊıÀàĞÍ
+	//æ ‡è®°å‡½æ•°ç±»å‹
 	std::map<unsigned int,eSymbolFuncType> eSymbolFuncTypeMap;
-	//´æ´¢ËùÓĞµÄ¿Ø¼şĞÅÏ¢,ÄÚÈİºÍallControlListÒ»Ñù
+	//å­˜å‚¨æ‰€æœ‰çš„æ§ä»¶ä¿¡æ¯,å†…å®¹å’ŒallControlListä¸€æ ·
 	std::map<eSymbol_ControlIndex, EAppControl*> allControlMap;
 };

--- a/E-Decompiler/ImportsParser.cpp
+++ b/E-Decompiler/ImportsParser.cpp
@@ -1,7 +1,8 @@
-#include "ImportsParser.h"
+ï»¿#include "ImportsParser.h"
 #include "SectionManager.h"
+#include "./Utils/Strings.h"
 #include <kernwin.hpp>
-#include "common/public.h"
+
 
 qvector<ImportsParser::ImportsApi> ImportsParser::mVec_ImportsApi;
 
@@ -46,7 +47,7 @@ int ImportsParser::MenuHandle_ShowImportsInfo()
 		}
 	};
 
-	qstring title = getUTF8String("ÓÃ»§µ¼Èë±í");
+	qstring title = getUTF8String("ç”¨æˆ·å¯¼å…¥è¡¨");
 	chooser_eImports* pUserChoose = new chooser_eImports(title.c_str());
 	pUserChoose->choose();
 	return 0;

--- a/E-Decompiler/ImportsParser.h
+++ b/E-Decompiler/ImportsParser.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <pro.h>
 
 class ImportsParser

--- a/E-Decompiler/Module/CTreeFixer.cpp
+++ b/E-Decompiler/Module/CTreeFixer.cpp
@@ -1,4 +1,4 @@
-#include "CTreeFixer.h"
+ï»¿#include "CTreeFixer.h"
 #include <hexrays.hpp>
 #include "../EDecompiler.h"
 #include <typeinf.hpp>
@@ -8,7 +8,7 @@
 #include <frame.hpp>
 #include <allins.hpp>
 
-//ÏÖ½×¶ÎÄ¿µÄÊÇÈÃ´úÂë¿É¶Á»¯£¬²»ÊÇÖ±½Óµ½Ô´Âë£¬Òò´ËÃ»±ØÒªÔÚ´úÂë×ª»»Ï¸½Ú½øĞĞ¹ı¶ÈÓÅ»¯
+//ç°é˜¶æ®µç›®çš„æ˜¯è®©ä»£ç å¯è¯»åŒ–ï¼Œä¸æ˜¯ç›´æ¥åˆ°æºç ï¼Œå› æ­¤æ²¡å¿…è¦åœ¨ä»£ç è½¬æ¢ç»†èŠ‚è¿›è¡Œè¿‡åº¦ä¼˜åŒ–
 
 void fix_KrnlDllCmd(cexpr_t* e, ESymbol& symbolTable)
 {
@@ -40,9 +40,9 @@ void fix_KrnlWriteProperty(cexpr_t* e, ESymbol& symbolTable)
 	if (!appControl) {
 		return;
 	}
-	//Éú³Éº¯ÊıÃû×Ö
+	//ç”Ÿæˆå‡½æ•°åå­—
 	qstring helperFuncName;
-	helperFuncName.sprnt("%s::%s_Ğ´ÊôĞÔ_%s", appControl->controlTypeName.c_str(),
+	helperFuncName.sprnt("%s::%s_å†™å±æ€§_%s", appControl->controlTypeName.c_str(),
 		appControl->controlName.c_str(), appControl->GetPropertyName(properIndex).c_str());
 	qstring utf8FuncName;
 	acp_utf8(&utf8FuncName, helperFuncName.c_str());
@@ -57,7 +57,7 @@ void fix_KrnlWriteProperty(cexpr_t* e, ESymbol& symbolTable)
 
 void fix_KrnlLibFunc(cexpr_t* e, ESymbol& symbolTable)
 {
-	//²ÎÊıÖÁÉÙÊÇÁ½¸ö
+	//å‚æ•°è‡³å°‘æ˜¯ä¸¤ä¸ª
 	carglist_t& argList = *(e->a);
 	if (argList.size() < 2) {
 		return;
@@ -91,9 +91,9 @@ void fix_KrnlReadProperty(cexpr_t* e, ESymbol& symbolTable)
 		return;
 	}
 
-	//Éú³Éº¯ÊıÃû×Ö
+	//ç”Ÿæˆå‡½æ•°åå­—
 	qstring helperFuncName;
-	helperFuncName.sprnt("%s::%s_¶ÁÊôĞÔ_%s", appControl->controlTypeName.c_str(),
+	helperFuncName.sprnt("%s::%s_è¯»å±æ€§_%s", appControl->controlTypeName.c_str(),
 		appControl->controlName.c_str(), appControl->GetPropertyName(properIndex).c_str());
 	qstring utf8FuncName;
 	acp_utf8(&utf8FuncName,helperFuncName.c_str());
@@ -102,7 +102,7 @@ void fix_KrnlReadProperty(cexpr_t* e, ESymbol& symbolTable)
 	e->x->cleanup();
 	e->x->replace_by(tmpHelper);
 
-	//clearÊÇÇåÀí²»¸É¾»Ö¸ÕëµÄ
+	//clearæ˜¯æ¸…ç†ä¸å¹²å‡€æŒ‡é’ˆçš„
 	//argList.erase(argList.begin(),argList.end());
 }
 
@@ -116,7 +116,7 @@ void fix_CalMultiArrayIndex(cexpr_t* e, ESymbol& symbolTable)
 struct CTreeFixer_Vistor : public ctree_visitor_t
 {
 	CTreeFixer_Vistor(ESymbol& s) :ctree_visitor_t(CV_FAST),symbolTable(s) {};
-	//·µ»Ø0±íÊ¾¼ÌĞø±éÀú
+	//è¿”å›0è¡¨ç¤ºç»§ç»­éå†
 	int idaapi visit_expr(cexpr_t* e) override
 	{
 		if (e->op == cot_call) {
@@ -163,7 +163,7 @@ void tryFixCTree(cfunc_t* cfunc,ESymbol& symbolTable)
 	return;
 }
 
-//½«¿éfromBlkÒÆ¶¯µ½¿étoBlkÎ²²¿
+//å°†å—fromBlkç§»åŠ¨åˆ°å—toBlkå°¾éƒ¨
 
 void mergeBlocks(mblock_t* dst, mblock_t* src)
 {

--- a/E-Decompiler/Module/CTreeFixer.h
+++ b/E-Decompiler/Module/CTreeFixer.h
@@ -1,6 +1,6 @@
-#pragma once
+ï»¿#pragma once
 
-//ĞŞ¸´Ò×ÓïÑÔ·´±àÒë½á¹û
+//ä¿®å¤æ˜“è¯­è¨€åç¼–è¯‘ç»“æœ
 
 class ESymbol;
 class CTreeFixer

--- a/E-Decompiler/Module/EAppControlXref.cpp
+++ b/E-Decompiler/Module/EAppControlXref.cpp
@@ -1,4 +1,4 @@
-#include "EAppControlXref.h"
+ï»¿#include "EAppControlXref.h"
 #include "../Utils/Strings.h"
 #include <hexrays.hpp>
 #include <ua.hpp>
@@ -16,8 +16,8 @@ EAppControlXref::EAppControlXref(ESymbol& s):symbolTable(s)
 
 void EAppControlXref::RegisterAction(void* owner)
 {
-	//×¢²á´°¿Ú²Ëµ¥
-	std::string menuName = LocalCpToUtf8("¿Ø¼ş½»²æÒıÓÃ");
+	//æ³¨å†Œçª—å£èœå•
+	std::string menuName = LocalCpToUtf8("æ§ä»¶äº¤å‰å¼•ç”¨");
 	const action_desc_t tmpXrefDesc = {
 	sizeof(action_desc_t),ACTION_EAPP_CONTROL_XREF,menuName.c_str(),this,
 	owner,nullptr,nullptr,0,ADF_OT_PLUGMOD };
@@ -100,14 +100,14 @@ int EAppControlXref::activate(action_activation_ctx_t* ctx)
 		return 0;
 	}
 
-	//±éÀúµÃµ½ËùÓĞµÄÒıÓÃ
+	//éå†å¾—åˆ°æ‰€æœ‰çš„å¼•ç”¨
 	std::vector<unsigned int> cRefList = IDAWrapper::getAllCodeXrefAddr(symbolTable.krnlJmp.Jmp_MWriteProperty);
 	eAppControlXrefData tmpXrefData;
 	for (unsigned int n = 0; n < cRefList.size(); ++n) {
 		if (getRWXrefAddrText(cRefList[n],tmpXrefData.text)) {
 			tmpXrefData.type = XrefWriteProperty;
 			tmpXrefData.xRefAddr = cRefList[n];
-			tmpXrefData.text = "Ğ´ÊôĞÔ_" + tmpXrefData.text;
+			tmpXrefData.text = "å†™å±æ€§_" + tmpXrefData.text;
 			allXrefData.push_back(tmpXrefData);
 		}
 	}
@@ -117,7 +117,7 @@ int EAppControlXref::activate(action_activation_ctx_t* ctx)
 		if (getRWXrefAddrText(cRefList[n], tmpXrefData.text)) {
 			tmpXrefData.type = XrefReadProperty;
 			tmpXrefData.xRefAddr = cRefList[n];
-			tmpXrefData.text = "¶ÁÊôĞÔ_" + tmpXrefData.text;
+			tmpXrefData.text = "è¯»å±æ€§_" + tmpXrefData.text;
 			allXrefData.push_back(tmpXrefData);
 		}
 	}
@@ -187,7 +187,7 @@ bool EAppControlXref::getExecuteXrefAddrText(unsigned int XrefAddr, std::string&
 	qstring funcName;
 	get_ea_name(&funcName, controlIns.ops[1].value);
 	outText.assign(funcName.c_str(),funcName.length());
-	//³¢ÊÔÈ¥³ıÀàÃû
+	//å°è¯•å»é™¤ç±»å
 	int iIndex = outText.find('.');
 	if (iIndex != -1) {
 		outText = outText.substr(iIndex + 1);
@@ -248,12 +248,8 @@ void EAppControlXref::showXrefList()
 			}
 
 			cols[2].sprnt("%08X", xRefList[n].xRefAddr);
-			if (xRefList[n].type == XrefExecute) {
-				cols[3] = qstring(xRefList[n].text.c_str());
-			}
-			else {
-				acp_utf8(&cols[3], xRefList[n].text.c_str());
-			}
+			// å­˜å‚¨å±‚å·²ç»Ÿä¸€ä¸º UTF-8, ç›´é€šæ˜¾ç¤º
+			cols[3] = xRefList[n].text.c_str();
 		}
 		size_t idaapi get_count(void) const
 		{
@@ -262,8 +258,7 @@ void EAppControlXref::showXrefList()
 	};
 
 	std::string xRefListTitle = "xref to " + this->currentAppControl->controlName;
-	qstring utf8Title;
-	acp_utf8(&utf8Title,xRefListTitle.c_str());
+	qstring utf8Title(xRefListTitle.c_str());
 	std::sort(allXrefData.begin(), allXrefData.end(), [](eAppControlXrefData& v1, eAppControlXrefData& v2) {
 		return v1.xRefAddr < v2.xRefAddr;
 		});

--- a/E-Decompiler/Module/EAppControlXref.h
+++ b/E-Decompiler/Module/EAppControlXref.h
@@ -1,16 +1,16 @@
-#pragma once
+ï»¿#pragma once
 #include <pro.h>
 #include <kernwin.hpp>
 #include <vector>
 
-//Ò×ÓïÑÔ¿Ø¼ş½»²æÒıÓÃ
+//æ˜“è¯­è¨€æ§ä»¶äº¤å‰å¼•ç”¨
 
 class ESymbol;
 struct EAppControl;
 
 class EAppControlXref:public action_handler_t
 {
-	//½»²æÒıÓÃÀàĞÍ
+	//äº¤å‰å¼•ç”¨ç±»å‹
 	enum eAppControlXrefType
 	{
 		XrefWriteProperty = 0x0,
@@ -26,18 +26,18 @@ class EAppControlXref:public action_handler_t
 	};
 public:
 	EAppControlXref(ESymbol& symbol);
-	//×¢²áHandler
+	//æ³¨å†ŒHandler
 	void RegisterAction(void* owner);
-	//Ìí¼Ó²Ëµ¥Ïî
+	//æ·»åŠ èœå•é¡¹
 	void AttachToPopupMenu(TWidget* view, TPopupMenu* p);
 private:
-	//³õÊ¼»¯½»²æÒıÓÃÊı¾İ
+	//åˆå§‹åŒ–äº¤å‰å¼•ç”¨æ•°æ®
 	bool initXrefData(unsigned int callAddr);
 	int activate(action_activation_ctx_t* ctx)override;
 	action_state_t idaapi update(action_update_ctx_t* ctx) override;
-	//»ñÈ¡¶ÁĞ´½»²æÒıÓÃµØÖ·µÄ¿Ø¼şĞÅÏ¢,·µ»Øfalse±íÊ¾Ê§°Ü
+	//è·å–è¯»å†™äº¤å‰å¼•ç”¨åœ°å€çš„æ§ä»¶ä¿¡æ¯,è¿”å›falseè¡¨ç¤ºå¤±è´¥
 	bool getRWXrefAddrText(unsigned int XrefAddr, std::string& outText);
-	//»ñÈ¡Ö´ĞĞ½»²æÒıÓÃµØÖ·µÄ¿Ø¼şĞÅÏ¢,·µ»Øfalse±íÊ¾Ê§°Ü
+	//è·å–æ‰§è¡Œäº¤å‰å¼•ç”¨åœ°å€çš„æ§ä»¶ä¿¡æ¯,è¿”å›falseè¡¨ç¤ºå¤±è´¥
 	bool getExecuteXrefAddrText(unsigned int XrefAddr, std::string& outText);
 	void showXrefList();
 private:

--- a/E-Decompiler/Module/ECSigMaker.cpp
+++ b/E-Decompiler/Module/ECSigMaker.cpp
@@ -1,4 +1,4 @@
-#include "ECSigMaker.h"
+ï»¿#include "ECSigMaker.h"
 #include "../Utils/Strings.h"
 #include "ECSigScanner.h"
 #include <funcs.hpp>
@@ -13,8 +13,8 @@ ECSigMaker::ECSigMaker(ESymbol& symbol):eSymbol(symbol)
 
 void ECSigMaker::RegisterAction(void* owner)
 {
-	//×¢²á´°¿Ú²Ëµ¥
-	std::string menuName = LocalCpToUtf8("Éú³ÉÒ×ÓïÑÔº¯ÊıÌØÕ÷");
+	//æ³¨å†Œçª—å£èœå•
+	std::string menuName = LocalCpToUtf8("ç”Ÿæˆæ˜“è¯­è¨€å‡½æ•°ç‰¹å¾");
 	const action_desc_t GenEsigDesc = {
 	sizeof(action_desc_t),ACTION_ECSIGMAKER,menuName.c_str(),this,
 	owner,nullptr,nullptr,0,ADF_OT_PLUGMOD};

--- a/E-Decompiler/Module/ECSigMaker.h
+++ b/E-Decompiler/Module/ECSigMaker.h
@@ -1,17 +1,17 @@
-#pragma once
+ï»¿#pragma once
 #include <pro.h>
 #include <kernwin.hpp>
 
-//ÖÆ×÷Ò×ÓïÑÔº¯ÊıÌØÕ÷
+//åˆ¶ä½œæ˜“è¯­è¨€å‡½æ•°ç‰¹å¾
 
 class ESymbol;
 class ECSigMaker:public action_handler_t
 {
 public:
 	ECSigMaker(ESymbol& symbol);
-	//×¢²áHandler
+	//æ³¨å†ŒHandler
 	void RegisterAction(void* owner);
-	//Ìí¼Ó²Ëµ¥Ïî
+	//æ·»åŠ èœå•é¡¹
 	void AttachToPopupMenu(TWidget* view, TPopupMenu* p);
 private:
 	int activate(action_activation_ctx_t* ctx)override;

--- a/E-Decompiler/Module/ECSigScanner.cpp
+++ b/E-Decompiler/Module/ECSigScanner.cpp
@@ -1,4 +1,4 @@
-#include "ECSigScanner.h"
+ï»¿#include "ECSigScanner.h"
 #include <string>
 #include <map>
 #include <pro.h>
@@ -16,7 +16,7 @@
 
 ECSigScanner gECSigScanner;
 
-//ÊÇ·ñÎªÒ×ÓïÑÔ±ê×¼º¯Êı
+//æ˜¯å¦ä¸ºæ˜“è¯­è¨€æ ‡å‡†å‡½æ•°
 
 bool isEStandardFunction(unsigned int startAddr)
 {
@@ -27,7 +27,7 @@ bool isEStandardFunction(unsigned int startAddr)
 	return false;
 }
 
-//³õÊ¼»¯ÌØÕ÷¿â
+//åˆå§‹åŒ–ç‰¹å¾åº“
 
 void initMSigMap(std::multimap<std::string, std::string>& sigMap)
 {
@@ -70,7 +70,7 @@ bool ECSigScanner::ScanECSigFunction(ESymbol* symbolTable)
 	std::multimap<std::string, std::string> map_MSig;
 	initMSigMap(map_MSig);
 
-	//Ã»ÌØÕ÷¿â¾Í²»ÓÃÊ¶±ğÌØÕ÷ÁË
+	//æ²¡ç‰¹å¾åº“å°±ä¸ç”¨è¯†åˆ«ç‰¹å¾äº†
 	if (!map_MSig.size()) {
 		return true;
 	}
@@ -104,7 +104,7 @@ std::string ECSigScanner::calFunctionMD5(unsigned int funcStartEA, bool bUseCach
 		}
 	}
 	
-	//¼ÇÂ¼º¯ÊıË³Ğò
+	//è®°å½•å‡½æ•°é¡ºåº
 	funcIndexMap[funcStartEA] = funcIndex++;
 
 	std::string retMD5;
@@ -118,7 +118,7 @@ std::string ECSigScanner::calFunctionMD5(unsigned int funcStartEA, bool bUseCach
 	this->currentEA = funcStartEA;
 	this->endEA = funcEndEA;
 	
-	//¿ªÊ¼´¦ÀíÊı¾İ
+	//å¼€å§‹å¤„ç†æ•°æ®
 	bool bFinish = false;
 	insn_t tmpIns;
 	do
@@ -140,7 +140,7 @@ std::string ECSigScanner::calFunctionMD5(unsigned int funcStartEA, bool bUseCach
 	return retMD5;
 }
 
-//ÏÈ¿´¿´idaÄ¬ÈÏµÄº¯ÊıÎ²²¿µÄÇé¿ö
+//å…ˆçœ‹çœ‹idaé»˜è®¤çš„å‡½æ•°å°¾éƒ¨çš„æƒ…å†µ
 
 unsigned int checkIDAEndAddr(unsigned int endEA)
 {
@@ -153,7 +153,7 @@ unsigned int checkIDAEndAddr(unsigned int endEA)
 	if (popInsAddr == -1) {
 		return -1;
 	}
-	//±ØĞëÊÇpop ebp
+	//å¿…é¡»æ˜¯pop ebp
 	if (tmpIns.itype != NN_pop || tmpIns.ops[0].reg != 5) {
 		return -1;
 	}
@@ -161,7 +161,7 @@ unsigned int checkIDAEndAddr(unsigned int endEA)
 	if (movInsAddr == -1) {
 		return -1;
 	}
-	//±ØĞëÊÇmov esp,ebp
+	//å¿…é¡»æ˜¯mov esp,ebp
 	if (tmpIns.itype != NN_mov || tmpIns.ops[0].reg != 4 || tmpIns.ops[1].reg != 5) {
 		return -1;
 	}
@@ -178,7 +178,7 @@ unsigned int ECSigScanner::guessFuncEndAddr(unsigned int funcAddr)
 	if (retAddr != -1) {
 		return retAddr;
 	}
-	//ÕÒ¸ö¿¿Æ×µÄµØÖ·
+	//æ‰¾ä¸ªé è°±çš„åœ°å€
 	segment_t* pSegment = getseg(pFunc->start_ea);
 	if (!pSegment) {
 		return BADADDR;
@@ -189,7 +189,7 @@ unsigned int ECSigScanner::guessFuncEndAddr(unsigned int funcAddr)
 	unsigned int startAddr = pFunc->start_ea;
 	unsigned int maxEndAddr = pFunc->end_ea + 0x10;
 	while (true) {
-		unsigned int searchAddr = bin_search2(startAddr, pSegment->end_ea, binPat, 0x0);
+		unsigned int searchAddr = bin_search(startAddr, pSegment->end_ea, binPat, 0x0);
 		if (searchAddr == BADADDR) {
 			continue;
 		}

--- a/E-Decompiler/Module/ECSigScanner.h
+++ b/E-Decompiler/Module/ECSigScanner.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <string>
 #include <map>
 #include <vector>
@@ -29,37 +29,37 @@ public:
 	static ECSigScanner& Instance();
 public:
 	bool ScanECSigFunction(ESymbol* s);
-	//»ñÈ¡º¯ÊıµÄMD5,bFuzzy±íÊ¾ÊÇ·ñÎªÄ£ºıÌØÕ÷
+	//è·å–å‡½æ•°çš„MD5,bFuzzyè¡¨ç¤ºæ˜¯å¦ä¸ºæ¨¡ç³Šç‰¹å¾
 	std::string GetFunctionMD5(unsigned int funcAddr, bool bFuzzy = false);
 private:
-	//bUseCache±íÊ¾ÊÇ·ñÊ¹ÓÃ»º´æ,bSubFunc±íÊ¾ÊÇ·ñÎª×Óº¯Êı
+	//bUseCacheè¡¨ç¤ºæ˜¯å¦ä½¿ç”¨ç¼“å­˜,bSubFuncè¡¨ç¤ºæ˜¯å¦ä¸ºå­å‡½æ•°
 	std::string calFunctionMD5(unsigned int funcAddr, bool bUseCache = false, bool bSubFunc = false);
-	//²ÂÒ»²Âº¯ÊıµÄ½áÊøµØÖ·
+	//çŒœä¸€çŒœå‡½æ•°çš„ç»“æŸåœ°å€
 	unsigned int guessFuncEndAddr(unsigned int funcAddr);
-	//Éú³ÉÔ­Ê¼Êı¾İÌØÕ÷,·µ»Øtrue±íÊ¾½áÊø½âÎö
+	//ç”ŸæˆåŸå§‹æ•°æ®ç‰¹å¾,è¿”å›trueè¡¨ç¤ºç»“æŸè§£æ
 	bool genSig_rawBinary();
 	bool genSig_main(insn_t& tmpIns, bool bSubFunc);
 
-	//´¦ÀíÁé»îµÄµ¥²Ù×÷ÊıÖ¸Áî,·µ»Øtrue±íÊ¾½áÊø½âÎö
+	//å¤„ç†çµæ´»çš„å•æ“ä½œæ•°æŒ‡ä»¤,è¿”å›trueè¡¨ç¤ºç»“æŸè§£æ
 	bool genSig_flexSingleInst(insn_t& ins);
-	//´¦ÀíÁé»îµÄË«²Ù×÷ÊıÖ¸Áî,·µ»Øtrue±íÊ¾½áÊø½âÎö
+	//å¤„ç†çµæ´»çš„åŒæ“ä½œæ•°æŒ‡ä»¤,è¿”å›trueè¡¨ç¤ºç»“æŸè§£æ
 	bool genSig_flexDoubleInst(insn_t& ins);
 
-	//Éú³ÉÍêÃÀÌØÕ÷
+	//ç”Ÿæˆå®Œç¾ç‰¹å¾
 	void genSig_PerfectOp(op_t& op, SigElement& outSig);
-	//Éú³ÉÄ£ºıÌØÕ÷
+	//ç”Ÿæˆæ¨¡ç³Šç‰¹å¾
 	void genSig_FuzzyOp(op_t& op,SigElement& outSig);
 
 private:
-	//keyÊÇº¯ÊıµØÖ·,valueÊÇº¯ÊıMD5ÌØÕ÷
+	//keyæ˜¯å‡½æ•°åœ°å€,valueæ˜¯å‡½æ•°MD5ç‰¹å¾
 	std::map<unsigned int, std::string> sigCacheMap;
 
-	//keyÊÇº¯ÊıµØÖ·,valueÊÇº¯ÊıË÷Òı
+	//keyæ˜¯å‡½æ•°åœ°å€,valueæ˜¯å‡½æ•°ç´¢å¼•
 	std::map<unsigned int, unsigned int> funcIndexMap;
-	//µ±Ç°º¯ÊıË÷Òı´óĞ¡
+	//å½“å‰å‡½æ•°ç´¢å¼•å¤§å°
 	unsigned int funcIndex;
 
-	//µ±Ç°Éú³É½á¹û
+	//å½“å‰ç”Ÿæˆç»“æœ
 	std::vector<SigElement> sigResult;
 
 

--- a/E-Decompiler/Module/MicroCodeFixer.cpp
+++ b/E-Decompiler/Module/MicroCodeFixer.cpp
@@ -1,10 +1,10 @@
-#include "MicrocodeFixer.h"
+ï»¿#include "MicrocodeFixer.h"
 #include "../ESymbol.h"
 #include <hexrays.hpp>
 #include <ua.hpp>
 #include <allins.hpp>
 
-//microcodeĞŞ¸´
+//microcodeä¿®å¤
 
 void microGen_PushDefaultArg(codegen_t& cdg)
 {
@@ -57,7 +57,7 @@ void microFix_PushDefaultArg(mblock_t* blk, minsn_t* ins, ESymbol* symbolTable)
 	return;
 }
 
-//Ã»ÓĞÈË»áÔÚºõÄãÊÇ·ñÊÍ·ÅÄÚ´æ
+//æ²¡æœ‰äººä¼šåœ¨ä¹ä½ æ˜¯å¦é‡Šæ”¾å†…å­˜
 
 void microFix_KrnlFreeMem(mblock_t* blk, minsn_t* ins, ESymbol* symbolTable)
 {

--- a/E-Decompiler/Module/MicroCodeFixer.h
+++ b/E-Decompiler/Module/MicroCodeFixer.h
@@ -1,6 +1,6 @@
-#pragma once
+ï»¿#pragma once
 
-//Î¢Âë¼¶±ğµÄ´úÂëĞŞ¸´
+//å¾®ç çº§åˆ«çš„ä»£ç ä¿®å¤
 
 
 struct ESymbol;

--- a/E-Decompiler/Module/ShowEventList.cpp
+++ b/E-Decompiler/Module/ShowEventList.cpp
@@ -1,4 +1,4 @@
-#include "ShowEventList.h"
+﻿#include "ShowEventList.h"
 #include "../ESymbol.h"
 #include <pro.h>
 #include <kernwin.hpp>
@@ -71,13 +71,13 @@ int ShowEventList(void* ud)
 			cols[0].sprnt("0x%08X", controlList[n].windowID);
 			cols[1].sprnt("0x%08X", controlList[n].controlID);
 			cols[2].sprnt("%08X", controlList[n].eventAddr);
-			acp_utf8(&cols[3], controlList[n].controlType.c_str());
-			acp_utf8(&cols[4], controlList[n].eventName.c_str());
+			// 存储层已统一为 UTF-8, 直通显示
+			cols[3] = controlList[n].controlType.c_str();
+			cols[4] = controlList[n].eventName.c_str();
 		}
 	};
 
-	qstring title;
-	acp_utf8(&title,"�ؼ��¼���Ϣ");
+	qstring title("控件事件信息");
 	chooser_EventInfo* pEventWindow = new chooser_EventInfo(title.c_str(),symbolTable);
 	pEventWindow->choose();
 	return 0;

--- a/E-Decompiler/Module/ShowEventList.h
+++ b/E-Decompiler/Module/ShowEventList.h
@@ -1,5 +1,5 @@
-#pragma once
+﻿#pragma once
 
-//չʾ�ؼ��¼��б�
+//展示控件事件列表
 
 int ShowEventList(void* ud);

--- a/E-Decompiler/Module/ShowImports.cpp
+++ b/E-Decompiler/Module/ShowImports.cpp
@@ -1,4 +1,4 @@
-#include "ShowImports.h"
+ï»¿#include "ShowImports.h"
 #include "../ESymbol.h"
 #include <pro.h>
 #include <kernwin.hpp>
@@ -74,8 +74,7 @@ int ShowImports(void* ud)
 		}
 	};
 
-	qstring title;
-	acp_utf8(&title, "ÓÃ»§µ¼Èë±í");
+	qstring title("ç”¨æˆ·å¯¼å…¥è¡¨");
 	chooser_ImportsInfo* pEventWindow = new chooser_ImportsInfo(title.c_str(), symbolTable);
 	pEventWindow->choose();
 	return 0;

--- a/E-Decompiler/Module/ShowImports.h
+++ b/E-Decompiler/Module/ShowImports.h
@@ -1,5 +1,5 @@
-#pragma once
+ï»¿#pragma once
 
-//Õ¹Ê¾Ò×ÓïÑÔµ¼Èë±í
+//å±•ç¤ºæ˜“è¯­è¨€å¯¼å…¥è¡¨
 
 int ShowImports(void* ud);

--- a/E-Decompiler/PropertyDelegate.h
+++ b/E-Decompiler/PropertyDelegate.h
@@ -1,16 +1,16 @@
-#pragma once
+ï»¿#pragma once
 #include <QtWidgets/QStyledItemDelegate>
 #include <QVariant>
 
 enum PropertyType_t
 {
-	ui_default = 0,             //Ä¬ÈÏÊý¾Ý
-	ui_LineEditor = 1000,       //ÆÕÍ¨µÄ±à¼­¿ò
-	ui_LineEditor_Disabled,     //½ûÖ¹µÄ±à¼­¿ò
-	ui_LineEditor_ReadOnly,     //Ö»¶ÁµÄ±à¼­¿ò
-	ui_ColorDialog,             //ÑÕÉ«Ñ¡Ôñ¿ò
-	ui_ComboBoxList,            //ÏÂÀ­¿ò
-	ui_ImageBox,                //Í¼Æ¬¿ò
+	ui_default = 0,             //é»˜è®¤æ•°æ®
+	ui_LineEditor = 1000,       //æ™®é€šçš„ç¼–è¾‘æ¡†
+	ui_LineEditor_Disabled,     //ç¦æ­¢çš„ç¼–è¾‘æ¡†
+	ui_LineEditor_ReadOnly,     //åªè¯»çš„ç¼–è¾‘æ¡†
+	ui_ColorDialog,             //é¢œè‰²é€‰æ‹©æ¡†
+	ui_ComboBoxList,            //ä¸‹æ‹‰æ¡†
+	ui_ImageBox,                //å›¾ç‰‡æ¡†
 };
 
 class PropertyDelegate :public QStyledItemDelegate
@@ -57,7 +57,7 @@ public:
 			case ui_ImageBox:
 			{
 				QLabel* ret = new QLabel(parent, Qt::Dialog | Qt::WindowCloseButtonHint);
-				ret->setWindowTitle(QStringLiteral("Í¼Æ¬"));
+				ret->setWindowTitle(QStringLiteral("å›¾ç‰‡"));
 				return ret;
 			}
 			default:
@@ -98,7 +98,7 @@ public:
 			{
 				QImage imageValue = index.model()->data(index, Qt::UserRole).value<QImage>();
 				if (!imageValue.isNull()) {
-					pItem->setText(QStringLiteral("ÓÐÊý¾Ý"));
+					pItem->setText(QStringLiteral("æœ‰æ•°æ®"));
 				}
 				else {
 					pItem->setText(QStringLiteral(""));
@@ -148,7 +148,7 @@ public:
 			{
 			case ui_ImageBox:
 			{
-				//Ê¹Í¼Æ¬Î»ÖÃ¾ÓÖÐ
+				//ä½¿å›¾ç‰‡ä½ç½®å±…ä¸­
 				//QRect centerRect;
 				//centerRect.setLeft((QApplication::desktop()->width() - option.rect.width()) / 2);
 				//centerRect.setTop((QApplication::desktop()->height() - option.rect.top()) / 2);

--- a/E-Decompiler/SectionManager.cpp
+++ b/E-Decompiler/SectionManager.cpp
@@ -1,4 +1,4 @@
-#include "SectionManager.h"
+﻿#include "SectionManager.h"
 #include <segment.hpp>
 #include <bytes.hpp>
 
@@ -48,7 +48,7 @@ ea_t SectionManager::SeachBin(qstring HexStr)
 		if (!pSegment) {
 			continue;
 		}
-		ret = bin_search2(pSegment->start_ea, pSegment->end_ea, binPat, 0x0);
+		ret = bin_search(pSegment->start_ea, pSegment->end_ea, binPat, 0x0);
 		if (ret != BADADDR) {
 			break;
 		}

--- a/E-Decompiler/SectionManager.h
+++ b/E-Decompiler/SectionManager.h
@@ -1,24 +1,24 @@
-#pragma once
+ï»¿#pragma once
 #include <pro.h>
 
 struct SegmentInfomation
 {
-	ea_t m_segStart;                   //Çø¶ÎÆğÊ¼µØÖ·
-	uint32 m_segSize;                  //Çø¶Î´óĞ¡
-	qstring m_segName;                 //Çø¶ÎÃû³Æ
-	qvector<unsigned char> m_segData;  //Çø¶ÎÊı¾İ
+	ea_t m_segStart;                   //åŒºæ®µèµ·å§‹åœ°å€
+	uint32 m_segSize;                  //åŒºæ®µå¤§å°
+	qstring m_segName;                 //åŒºæ®µåç§°
+	qvector<unsigned char> m_segData;  //åŒºæ®µæ•°æ®
 };
 
 class SectionManager
 {
 public:
-	//³õÊ¼»¯³ÌĞòÇø¶Î
+	//åˆå§‹åŒ–ç¨‹åºåŒºæ®µ
 	static bool InitSectionManager();
-	//ÏßĞÔµØÖ·×ª»»ÎªĞéÄâµØÖ·
+	//çº¿æ€§åœ°å€è½¬æ¢ä¸ºè™šæ‹Ÿåœ°å€
 	static uint8* LinearAddrToVirtualAddr(ea_t LinerAddr);
-	//ĞéÄâµØÖ·×ª»»ÎªÏßĞÔµØÖ·
+	//è™šæ‹Ÿåœ°å€è½¬æ¢ä¸ºçº¿æ€§åœ°å€
 	static ea_t VirtualAddrToLinearAddr(uint8* pVirtualAddr);
-	//Ñ°ÕÒµØÖ·,²ÎÊıÎªÊ®Áù½øÖÆÌØÕ÷
+	//å¯»æ‰¾åœ°å€,å‚æ•°ä¸ºåå…­è¿›åˆ¶ç‰¹å¾
 	static ea_t SeachBin(qstring HexStr);
 private:
 	static qvector<SegmentInfomation> mVec_segInfo;

--- a/E-Decompiler/TrieTree.cpp
+++ b/E-Decompiler/TrieTree.cpp
@@ -1,4 +1,4 @@
-#include "TrieTree.h"
+ï»¿#include "TrieTree.h"
 #include <ida.hpp>
 #include <kernwin.hpp>
 #include <diskio.hpp>
@@ -13,7 +13,7 @@ bool FastMatch_CmpApi(unsigned char* pSrc, qstring IATEAT)
 	qstring EATCom;
 
 	int EATpos = IATEAT.find("||");
-	if (EATpos != -1) {            //´æÔÚ×Ô¶¨ÒåEAT
+	if (EATpos != -1) {            //å­˜åœ¨è‡ªå®šä¹‰EAT
 		IATCom = IATEAT.substr(0, EATpos);
 		EATCom = IATEAT.substr(EATpos + 2);
 	}
@@ -83,7 +83,7 @@ bool TrieTree::SlowMatch_CmpCallApi(unsigned char* pSrc,qstring IATEAT)
 	qstring EATCom;
 
 	int EATpos = IATEAT.find("||");
-	if (EATpos != -1) {            //´æÔÚ×Ô¶¨ÒåEAT
+	if (EATpos != -1) {            //å­˜åœ¨è‡ªå®šä¹‰EAT
 		IATCom = IATEAT.substr(0, EATpos);
 		EATCom = IATEAT.substr(EATpos + 2);
 	}
@@ -126,13 +126,13 @@ TrieTree::TrieTree()
 	root = new TrieTreeNode();
 	root->SpecialType = NODE_NORMAL;
 
-	//Ä¬ÈÏÅäÖÃ
+	//é»˜è®¤é…ç½®
 	m_IsAligned = false;
 	m_IsSetName = true;
 	m_MatchSubName = false;
 }
 
-//Ê®Áùµ½Ê®
+//åå…­åˆ°å
 void HexStrToBin(qstring& HexCode, unsigned char* BinCode)
 {
 	for (uint n = 0; n < HexCode.length() / 2; n++) {
@@ -147,31 +147,31 @@ TrieTreeNode* TrieTree::AddNode(TrieTreeNode* p, qstring Txt) {
 		return p->ChildNodes[index];
 	}
 
-	TrieTreeNode* NewNode = new TrieTreeNode(); //Èç¹ûËùÓĞµÄ½ÚµãÖĞ¶¼Ã»ÓĞ,Ôò´´½¨Ò»¸öĞÂ½Úµã
-	p->ChildNodes[index] = NewNode;      //µ±Ç°½Úµã¼ÓÈëĞÂ×Ó½Úµã
+	TrieTreeNode* NewNode = new TrieTreeNode(); //å¦‚æœæ‰€æœ‰çš„èŠ‚ç‚¹ä¸­éƒ½æ²¡æœ‰,åˆ™åˆ›å»ºä¸€ä¸ªæ–°èŠ‚ç‚¹
+	p->ChildNodes[index] = NewNode;      //å½“å‰èŠ‚ç‚¹åŠ å…¥æ–°å­èŠ‚ç‚¹
 
-	NewNode->EsigText = new char[Txt.length() + 1]; qstrncpy(NewNode->EsigText, Txt.c_str(), MAXSTR);//¸³ÖµEsigTxt
+	NewNode->EsigText = new char[Txt.length() + 1]; qstrncpy(NewNode->EsigText, Txt.c_str(), MAXSTR);//èµ‹å€¼EsigTxt
 	MemAllocSave.push_back(NewNode->EsigText);
 	NewNode->SpecialType = NODE_NORMAL;
 	return NewNode;
 }
 
 TrieTreeNode* TrieTree::AddSpecialNode(TrieTreeNode* p, uint type, qstring Txt) {
-	for (int i = 0; i < p->SpecialNodes.size(); i++) {		//±éÀúµ±Ç°×Ó½Úµã
+	for (int i = 0; i < p->SpecialNodes.size(); i++) {		//éå†å½“å‰å­èŠ‚ç‚¹
 		if (p->SpecialNodes[i]->SpecialType == type && Txt == p->SpecialNodes[i]->EsigText) {
 			return p->SpecialNodes[i];
 		}
 	}
-	TrieTreeNode* NewNode = new TrieTreeNode(); //Èç¹ûËùÓĞµÄ½ÚµãÖĞ¶¼Ã»ÓĞ,Ôò´´½¨Ò»¸öĞÂ½Úµã
-	p->SpecialNodes.push_back(NewNode);      //µ±Ç°½Úµã¼ÓÈëĞÂ×Ó½Úµã
-	NewNode->EsigText = new char[Txt.length() + 1]; qstrncpy(NewNode->EsigText, Txt.c_str(), MAXSTR);//¸³ÖµEsigTxt
+	TrieTreeNode* NewNode = new TrieTreeNode(); //å¦‚æœæ‰€æœ‰çš„èŠ‚ç‚¹ä¸­éƒ½æ²¡æœ‰,åˆ™åˆ›å»ºä¸€ä¸ªæ–°èŠ‚ç‚¹
+	p->SpecialNodes.push_back(NewNode);      //å½“å‰èŠ‚ç‚¹åŠ å…¥æ–°å­èŠ‚ç‚¹
+	NewNode->EsigText = new char[Txt.length() + 1]; qstrncpy(NewNode->EsigText, Txt.c_str(), MAXSTR);//èµ‹å€¼EsigTxt
 	MemAllocSave.push_back(NewNode->EsigText);
 	NewNode->SpecialType = type;
 	return NewNode;
 }
 
-bool TrieTree::Insert(qstring& FuncTxt, const qstring& FuncName) {		//²ÎÊıÒ»Îªº¯ÊıµÄÎÄ±¾ĞÎÊ½,²ÎÊı¶şÎªº¯ÊıµÄÃû³Æ
-	TrieTreeNode* p = root;		//½«µ±Ç°½ÚµãÖ¸ÕëÖ¸ÏòROOT½Úµã
+bool TrieTree::Insert(qstring& FuncTxt, const qstring& FuncName) {		//å‚æ•°ä¸€ä¸ºå‡½æ•°çš„æ–‡æœ¬å½¢å¼,å‚æ•°äºŒä¸ºå‡½æ•°çš„åç§°
+	TrieTreeNode* p = root;		//å°†å½“å‰èŠ‚ç‚¹æŒ‡é’ˆæŒ‡å‘ROOTèŠ‚ç‚¹
 
 	qstring BasicTxt;
 	qstring SpecialTxt;
@@ -181,14 +181,14 @@ bool TrieTree::Insert(qstring& FuncTxt, const qstring& FuncName) {		//²ÎÊıÒ»Îªº¯
 		char test = FuncTxt[n];
 		switch (FuncTxt[n])
 		{
-		case '-':	//Check 1´Î
+		case '-':	//Check 1æ¬¡
 			if (FuncTxt[n + 1] == '-' && FuncTxt[n + 2] == '>')
 			{
 				BasicTxt = "E9";
 				p = AddNode(p, BasicTxt);
 				p = AddSpecialNode(p, NODE_LONGJMP, "");
 				n = n + 2;
-				continue;		//´ËcontinueÊôÓÚÍâ²¿Ñ­»·
+				continue;		//æ­¤continueå±äºå¤–éƒ¨å¾ªç¯
 			}
 			return false;
 		case '<':
@@ -201,12 +201,12 @@ bool TrieTree::Insert(qstring& FuncTxt, const qstring& FuncName) {		//²ÎÊıÒ»Îªº¯
 				p = AddNode(p, BasicTxt);
 				BasicTxt = "15";
 				p = AddNode(p, BasicTxt);
-				SpecialTxt = FuncTxt.substr(n + 2, post);   //µÃµ½ÎÄ±¾ÖĞµÄIATº¯Êı
+				SpecialTxt = FuncTxt.substr(n + 2, post);   //å¾—åˆ°æ–‡æœ¬ä¸­çš„IATå‡½æ•°
 				p = AddSpecialNode(p, NODE_CALLAPI, SpecialTxt);
 				n = post + 1;
 				continue;
 			}
-			else {											//ÆÕÍ¨µÄº¯ÊıCALL
+			else {											//æ™®é€šçš„å‡½æ•°CALL
 				int post = FuncTxt.find('>', n);
 				if (post == -1) {
 					return false;
@@ -239,30 +239,30 @@ bool TrieTree::Insert(qstring& FuncTxt, const qstring& FuncName) {		//²ÎÊıÒ»Îªº¯
 			}
 		case '?':
 			if (FuncTxt[n + 1] == '?') {
-				p = AddSpecialNode(p, NODE_ALLPASS, FuncTxt.substr(n, n + 2));	//È«Í¨Åä·û
+				p = AddSpecialNode(p, NODE_ALLPASS, FuncTxt.substr(n, n + 2));	//å…¨é€šé…ç¬¦
 				n = n + 1;
 				continue;
 			}
 			else
 			{
-				p = AddSpecialNode(p, NODE_LEFTPASS, FuncTxt.substr(n, n + 2));	//×óÍ¨Åä·û
+				p = AddSpecialNode(p, NODE_LEFTPASS, FuncTxt.substr(n, n + 2));	//å·¦é€šé…ç¬¦
 				n = n + 1;
 				continue;
 			}
 		case '!':
 		{
-			int post = FuncTxt.find('!', n + 1);	//´Ó!µÄÏÂÒ»¸ö×Ö·û¿ªÊ¼Ñ°ÕÒ!
+			int post = FuncTxt.find('!', n + 1);	//ä»!çš„ä¸‹ä¸€ä¸ªå­—ç¬¦å¼€å§‹å¯»æ‰¾!
 			if (post == -1) {
 				return false;
 			}
 			SpecialTxt = FuncTxt.substr(n + 1, post);
 			p = AddSpecialNode(p, NODE_CONSTANT, SpecialTxt);
-			n = post;	//½«µ±Ç°Ö¸ÕëÖ¸ÏòÓÒ±ßµÄ!ºÅ
+			n = post;	//å°†å½“å‰æŒ‡é’ˆæŒ‡å‘å³è¾¹çš„!å·
 			continue;
 		}
 		default:
 			if (FuncTxt[n + 1] == '?') {
-				p = AddSpecialNode(p, NODE_RIGHTPASS, FuncTxt.substr(n, n + 2));	//ÓÒÍ¨Åä·û
+				p = AddSpecialNode(p, NODE_RIGHTPASS, FuncTxt.substr(n, n + 2));	//å³é€šé…ç¬¦
 				n = n + 1;
 				continue;
 			}
@@ -275,7 +275,7 @@ bool TrieTree::Insert(qstring& FuncTxt, const qstring& FuncName) {		//²ÎÊıÒ»Îªº¯
 		}
 	}
 
-	if (p->FuncName) {		//È·±£º¯ÊıÃû³ÆÎ¨Ò»ĞÔ£¡£¡£¡
+	if (p->FuncName) {		//ç¡®ä¿å‡½æ•°åç§°å”¯ä¸€æ€§ï¼ï¼ï¼
 		msg("Find The same Function--%s", p->FuncName);
 		for (uint i = 0; i < MemAllocSave.size(); i++)
 		{
@@ -296,13 +296,13 @@ TrieTree::~TrieTree()
 		return;
 	}
 
-	qstack<TrieTreeNode*> StackNode;	//½Úµã
+	qstack<TrieTreeNode*> StackNode;	//èŠ‚ç‚¹
 	StackNode.push(p);
 
 	while (!StackNode.empty()) {
 		p = StackNode.top();
 		StackNode.pop();
-		//È¡»Ø¶ÑÕ»¶¥¶Ë½Úµã
+		//å–å›å †æ ˆé¡¶ç«¯èŠ‚ç‚¹
 		if (p)
 		{
 			for (uint i = 0; i < 256; i++)
@@ -358,7 +358,7 @@ bool TrieTree::FastMatch(TrieTreeNode* p, unsigned char*& FuncSrc)
 	{
 		unsigned char* pCallSrc = FuncSrc - 1 + ReadInt(FuncSrc) + 5;
 		uint32 oaddr = SectionManager::VirtualAddrToLinearAddr(pCallSrc);
-		if (m_RFunc[oaddr] == p->EsigText)	//´Ëº¯ÊıÒÑ¾­Æ¥Åä¹ıÒ»´Î
+		if (m_RFunc[oaddr] == p->EsigText)	//æ­¤å‡½æ•°å·²ç»åŒ¹é…è¿‡ä¸€æ¬¡
 		{
 			FuncSrc = FuncSrc + 4;
 			return true;
@@ -424,7 +424,7 @@ bool TrieTree::FastMatch(TrieTreeNode* p, unsigned char*& FuncSrc)
 
 bool TrieTree::SlowMatch(unsigned char* FuncSrc, qstring& FuncTxt)
 {
-	unsigned char* pSrc = FuncSrc;  //³õÊ¼»¯º¯Êı´úÂëÖ¸Õë
+	unsigned char* pSrc = FuncSrc;  //åˆå§‹åŒ–å‡½æ•°ä»£ç æŒ‡é’ˆ
 	if (FuncTxt == "")
 	{
 		return false;
@@ -436,7 +436,7 @@ bool TrieTree::SlowMatch(unsigned char* FuncSrc, qstring& FuncTxt)
 		switch (FuncTxt[n]) {
 		case '-':
 		{
-			if (FuncTxt[n + 1] == '-' && FuncTxt[n + 2] == '>') {		//³¤Ìø×ª
+			if (FuncTxt[n + 1] == '-' && FuncTxt[n + 2] == '>') {		//é•¿è·³è½¬
 				if (*pSrc != 0xE9) {
 					return false;
 				}
@@ -504,12 +504,12 @@ bool TrieTree::SlowMatch(unsigned char* FuncSrc, qstring& FuncTxt)
 		}
 		case '?':
 		{
-			if (FuncTxt[n + 1] == '?') {	                                  //È«Í¨Åä·û
+			if (FuncTxt[n + 1] == '?') {	                                  //å…¨é€šé…ç¬¦
 				pSrc = pSrc + 1;
 				n = n + 2;
 				continue;
 			}
-			else if ((ReadUChar(pSrc) & 0xF) == HexToBin(FuncTxt[n + 1])) {   //×óÍ¨Åä·û
+			else if ((ReadUChar(pSrc) & 0xF) == HexToBin(FuncTxt[n + 1])) {   //å·¦é€šé…ç¬¦
 				pSrc = pSrc + 1;
 				n = n + 2;
 				continue;
@@ -518,7 +518,7 @@ bool TrieTree::SlowMatch(unsigned char* FuncSrc, qstring& FuncTxt)
 		}
 		default:
 		{
-			if (FuncTxt[n + 1] == '?') {                                      //ÓÒÍ¨Åä·û
+			if (FuncTxt[n + 1] == '?') {                                      //å³é€šé…ç¬¦
 				if ((ReadUChar(pSrc) >> 4) == HexToBin(FuncTxt[n])) {
 					pSrc = pSrc + 1;
 					n = n + 2;
@@ -543,22 +543,22 @@ bool TrieTree::SlowMatch(unsigned char* FuncSrc, qstring& FuncTxt)
 
 char* TrieTree::MatchFunc(unsigned char* FuncSrc)
 {
-	TrieTreeNode* p = root;		                //µ±Ç°Ö¸ÕëÖ¸Ïòroot
+	TrieTreeNode* p = root;		                //å½“å‰æŒ‡é’ˆæŒ‡å‘root
 
-	qstack<TrieTreeNode*> StackNode;	        //½Úµã
-	qstack<unsigned char*> StackFuncSrc;        //½ÚµãµØÖ·
+	qstack<TrieTreeNode*> StackNode;	        //èŠ‚ç‚¹
+	qstack<unsigned char*> StackFuncSrc;        //èŠ‚ç‚¹åœ°å€
 
 	StackNode.push(p);
 	StackFuncSrc.push(FuncSrc);
-	//½øÈëÑ­»·³õÊ¼Ìõ¼ş
+	//è¿›å…¥å¾ªç¯åˆå§‹æ¡ä»¶
 
 	while (!StackNode.empty()) {
 		p = StackNode.top();
 		StackNode.pop();
 		FuncSrc = StackFuncSrc.top();
 		StackFuncSrc.pop();
-		//È¡»Ø¶ÑÕ»¶¥¶Ë½Úµã
-		if (!FastMatch(p, FuncSrc)) {		//¼ì²éµ±Ç°½ÚµãºÏ·¨ĞÔÓÅÏÈ¼¶¸ßÓÚÅĞ¶ÏÖÕ½Úµã
+		//å–å›å †æ ˆé¡¶ç«¯èŠ‚ç‚¹
+		if (!FastMatch(p, FuncSrc)) {		//æ£€æŸ¥å½“å‰èŠ‚ç‚¹åˆæ³•æ€§ä¼˜å…ˆçº§é«˜äºåˆ¤æ–­ç»ˆèŠ‚ç‚¹
 			continue;
 		}
 		if (p->FuncName) {
@@ -596,9 +596,9 @@ bool TrieTree::LoadSig(const char* lpMapPath)
 
 	qstring SubFunc = GetMidString(str_Map, "*****SubFunc*****\r\n", "*****SubFunc_End*****", 0);
 
-	int pos = SubFunc.find("\r\n");     //×Óº¯Êı
+	int pos = SubFunc.find("\r\n");     //å­å‡½æ•°
 	while (pos != -1) {
-		qstring temp = SubFunc.substr(0, pos);  //µ¥¸ö×Óº¯Êı
+		qstring temp = SubFunc.substr(0, pos);  //å•ä¸ªå­å‡½æ•°
 		if (temp == "")
 		{
 			SubFunc = SubFunc.substr(SubFunc.find("\r\n") + 2);
@@ -620,10 +620,10 @@ bool TrieTree::LoadSig(const char* lpMapPath)
 
 	qstring Func = GetMidString(str_Map, "***Func***\r\n", "***Func_End***", 0);
 
-	pos = Func.find("\r\n");//·Ö¸îÎÄ±¾
+	pos = Func.find("\r\n");//åˆ†å‰²æ–‡æœ¬
 	while (pos != -1) {
-		qstring temp = Func.substr(0, pos);    //È¡³öµ¥¸öº¯ÊıÎÄ±¾
-		if (temp == "")		//µÃµ½¿ÕĞĞ
+		qstring temp = Func.substr(0, pos);    //å–å‡ºå•ä¸ªå‡½æ•°æ–‡æœ¬
+		if (temp == "")		//å¾—åˆ°ç©ºè¡Œ
 		{
 			Func = Func.substr(Func.find("\r\n") + 2);
 			pos = Func.find("\r\n");
@@ -638,7 +638,7 @@ bool TrieTree::LoadSig(const char* lpMapPath)
 			tempos = temp.find(':', tempos + 2);
 		}
 		if (!Insert(temp.substr(tempos + 1), temp.substr(0, tempos))) {
-			msg("²åÈëº¯ÊıÊ§°Ü\r\n");
+			msg("æ’å…¥å‡½æ•°å¤±è´¥\r\n");
 		}
 		Func = Func.substr(pos + 2);
 		pos = Func.find("\r\n");

--- a/E-Decompiler/TrieTree.h
+++ b/E-Decompiler/TrieTree.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <ida.hpp>
 #include <windows.h>
 #include <funcs.hpp>
@@ -11,10 +11,10 @@ public:
 	qvector<TrieTreeNode*> SpecialNodes;
 	TrieTreeNode** ChildNodes;
 
-	uint32 SpecialType;	//Ò»¸öÊı×Ö´ú±íÀàĞÍ
-	char* EsigText;		//Ò»¶ÎÎÄ×Ö´ú±íÊı¾İ
-	char* FuncName;		//º¯ÊıÃû³Æ
-	bool IsMatched;     //ÊÇ·ñÒÑ¾­Æ¥Åä¹ı
+	uint32 SpecialType;	//ä¸€ä¸ªæ•°å­—ä»£è¡¨ç±»å‹
+	char* EsigText;		//ä¸€æ®µæ–‡å­—ä»£è¡¨æ•°æ®
+	char* FuncName;		//å‡½æ•°åç§°
+	bool IsMatched;     //æ˜¯å¦å·²ç»åŒ¹é…è¿‡
 };
 
 class TrieTree
@@ -23,21 +23,21 @@ public:
 	TrieTree();
 	~TrieTree();
 
-	//ÈÕÖ¾,´òÓ¡×Óº¯Êı½á¹û
+	//æ—¥å¿—,æ‰“å°å­å‡½æ•°ç»“æœ
 	void Log_PrintSubFunc();
-	//¼ÓÔØÌØÕ÷Âë
+	//åŠ è½½ç‰¹å¾ç 
 	bool LoadSig(const char* lpMapPath);
-	//Ö´ĞĞº¯ÊıÆ¥Åä
+	//æ‰§è¡Œå‡½æ•°åŒ¹é…
 	char* MatchFunc(unsigned char* CodeSrc);
 private:
-	//Ôö¼ÓÆÕÍ¨½Úµã
+	//å¢åŠ æ™®é€šèŠ‚ç‚¹
 	TrieTreeNode* AddNode(TrieTreeNode* p, qstring Txt);
-	//Ôö¼ÓÌØÊâ½Úµã
+	//å¢åŠ ç‰¹æ®ŠèŠ‚ç‚¹
 	TrieTreeNode* AddSpecialNode(TrieTreeNode* p, uint type, qstring Txt);
 
-	//¿ìËÙÆ¥ÅäÌØÕ÷Âë
+	//å¿«é€ŸåŒ¹é…ç‰¹å¾ç 
 	bool FastMatch(TrieTreeNode* p, unsigned char*& FuncSrc);
-	//ÂıËÙÆ¥ÅäÌØÕ÷Âë
+	//æ…¢é€ŸåŒ¹é…ç‰¹å¾ç 
 	bool SlowMatch(unsigned char* FuncSrc, qstring& FuncTxt);
 
 	bool SlowMatch_CmpCallApi(unsigned char* pSrc, qstring IATEAT);
@@ -45,7 +45,7 @@ private:
 public:
 	qvector<char*>  MemAllocSave;
 
-	//ĞŞ¸Äº¯ÊıµÄÃû³Æ
+	//ä¿®æ”¹å‡½æ•°çš„åç§°
 	bool m_IsSetName;
 	bool m_IsAligned;
 	bool m_IsAllMem;
@@ -66,13 +66,13 @@ private:
 		NODE_RIGHTPASS = 12,       //       ?
 		NODE_ALLPASS = 13          //      ??
 	};
-	//¸ù½Úµã
+	//æ ¹èŠ‚ç‚¹
 	TrieTreeNode* root;
 	//func_t* func;
 
-	//×Óº¯Êı,º¯ÊıÃû³ÆºÍº¯ÊıÎÄ±¾Ò»Ò»Ó³Éä
+	//å­å‡½æ•°,å‡½æ•°åç§°å’Œå‡½æ•°æ–‡æœ¬ä¸€ä¸€æ˜ å°„
 	std::map<qstring, qstring> m_subFunc;	
 
-	 //R´ú±íRuntime,ÔËĞĞÊ±¼ÇÂ¼Êµ¼ÊµØÖ·¶ÔÓ¦º¯Êı,²»ÒªÊÔÍ¼Ò»¸öµØÖ·¶à¸öº¯ÊıÃû³Æ ,²ÎÊıÒ»ÎªÊµ¼ÊÄÚ´æµØÖ·,²ÎÊı¶şÎª¶ÔÓ¦Ãû³Æ
+	 //Rä»£è¡¨Runtime,è¿è¡Œæ—¶è®°å½•å®é™…åœ°å€å¯¹åº”å‡½æ•°,ä¸è¦è¯•å›¾ä¸€ä¸ªåœ°å€å¤šä¸ªå‡½æ•°åç§° ,å‚æ•°ä¸€ä¸ºå®é™…å†…å­˜åœ°å€,å‚æ•°äºŒä¸ºå¯¹åº”åç§°
 	std::map<uint32, qstring> m_RFunc; 
 };

--- a/E-Decompiler/Utils/Common.cpp
+++ b/E-Decompiler/Utils/Common.cpp
@@ -1,4 +1,4 @@
-#include "Common.h"
+﻿#include "Common.h"
 #include <windows.h>
 
 unsigned char BinMap[256] = {

--- a/E-Decompiler/Utils/Common.h
+++ b/E-Decompiler/Utils/Common.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <string>
 #include <vector>
 
@@ -9,10 +9,10 @@ unsigned char ReadUChar(char* pBuf);
 std::string ReadStr(unsigned char* pBuf);
 
 
-//ʮ����ʮ,a -> 10
+//十六到十,a -> 10
 unsigned char HexToBin(unsigned char HexCode);
 
-//ö��Ŀ¼�ļ�
+//枚举目录文件
 
 std::vector<std::string> enumDirectoryFiles(const char *dir);
 

--- a/E-Decompiler/Utils/IDAMenu.cpp
+++ b/E-Decompiler/Utils/IDAMenu.cpp
@@ -1,4 +1,4 @@
-#include "IDAMenu.h"
+﻿#include "IDAMenu.h"
 #include <loader.hpp>
 
 IDAMenu::IDAMenu(const char* menuPath, int (*callback)(void*), void* ud,const char* shortcut, const char* tooltip, int icon)

--- a/E-Decompiler/Utils/IDAMenu.h
+++ b/E-Decompiler/Utils/IDAMenu.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <pro.h>
 #include <kernwin.hpp>
 
@@ -21,13 +21,13 @@ private:
 private:
 	int (*m_callback)(void*);
 	void* m_userData;
-	//¶¯×÷µÄÄÚ²¿Ãû³Æ
+	//åŠ¨ä½œçš„å†…éƒ¨åç§°
 	qstring m_actionName;
-	//¶¯×÷µÄ±êÇ©Ãû³Æ
+	//åŠ¨ä½œçš„æ ‡ç­¾åç§°
 	qstring m_actionLabel;
 
-	//²Ëµ¥µÄÄÚ²¿Ãû³Æ
+	//èœå•çš„å†…éƒ¨åç§°
 	qstring m_menuName;
-	//²Ëµ¥µÄ±êÇ©Ãû³Æ
+	//èœå•çš„æ ‡ç­¾åç§°
 	qstring m_menuLabel;
 };

--- a/E-Decompiler/Utils/IDAWrapper.cpp
+++ b/E-Decompiler/Utils/IDAWrapper.cpp
@@ -1,4 +1,4 @@
-#include "IDAWrapper.h"
+ï»¿#include "IDAWrapper.h"
 #include <pro.h>
 #include <kernwin.hpp>
 #include <bytes.hpp>
@@ -39,7 +39,7 @@ std::string IDAWrapper::get_shortstring(unsigned int addr)
 		return "";
 	}
 	char buffer[255] = { 0 };
-	//Ã»¶ÁÈ¡µ½ÍêÕûµÄ×Ö½ÚÓ¦¸ÃËãÊÇ´íÎóÁË
+	//æ²¡è¯»å–åˆ°å®Œæ•´çš„å­—èŠ‚åº”è¯¥ç®—æ˜¯é”™è¯¯äº†
 	if (get_bytes(buffer, sizeof(buffer), addr, GMB_READALL, NULL) != sizeof(buffer))
 	{
 		return "";
@@ -61,9 +61,8 @@ void IDAWrapper::setFuncName(unsigned int addr, const char* funcName, bool bForc
 			return;
 		}
 	}
-	qstring newName;
-	acp_utf8(&newName, funcName);
-	set_name(addr, newName.c_str(), SN_NOWARN | SN_FORCE);
+	// è¾“å…¥é¡»ä¸º UTF-8 (IDA 9.4 åŸç”Ÿ); äºŒè¿›åˆ¶/esig ä¸­çš„ GBK æ•°æ®åœ¨è§£æå±‚å…ˆè½¬æ¢
+	set_name(addr, funcName, SN_NOWARN | SN_FORCE);
 }
 
 void IDAWrapper::msg(const char* format, ...)
@@ -116,7 +115,8 @@ std::vector<std::string> IDAWrapper::enumerate_files(const char* dir, const char
 		}
 	};
 	MyFileEnumerator fileEnumFunc(retFileList);
-	enumerate_files2(0, 0, dir, fname, fileEnumFunc);
+	char answer[QMAXPATH];
+	::enumerate_files(answer, sizeof(answer), dir, fname, fileEnumFunc);
 	return retFileList;
 }
 

--- a/E-Decompiler/Utils/IDAWrapper.h
+++ b/E-Decompiler/Utils/IDAWrapper.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <string>
 #include <vector>
 
@@ -12,18 +12,18 @@ namespace IDAWrapper{
 
 	const char* idadir(const char* subdir);
 
-	//ÉèÖÃº¯ÊıÃû³Æ
+	//è®¾ç½®å‡½æ•°åç§°
 	void setFuncName(unsigned int addr, const char* funcName, bool bForce = true);
 
 	void msg(const char* format, ...);
 
 	bool apply_cdecl(unsigned int ea, const char* decl, int flags = 0);
 
-	//»ñÈ¡´úÂë½»²æÒıÓÃµØÖ·
+	//è·å–ä»£ç äº¤å‰å¼•ç”¨åœ°å€
 	std::vector<unsigned int> getAllCodeXrefAddr(unsigned int addr);
 
 	bool add_user_stkpnt(unsigned int ea, int delta);
 	
-	//Ã¶¾ÙÖ¸¶¨Ä¿Â¼ÎÄ¼ş
+	//æšä¸¾æŒ‡å®šç›®å½•æ–‡ä»¶
 	std::vector<std::string> enumerate_files(const char* dir, const char* fname);
 }

--- a/E-Decompiler/Utils/Strings.cpp
+++ b/E-Decompiler/Utils/Strings.cpp
@@ -1,4 +1,4 @@
-#include "Strings.h"
+﻿#include "Strings.h"
 #include <windows.h>
 
 std::wstring LocalCpToUtf16(const char* str)

--- a/E-Decompiler/Utils/Strings.h
+++ b/E-Decompiler/Utils/Strings.h
@@ -1,6 +1,14 @@
-#pragma once
+﻿#pragma once
 #include <string>
+#include <pro.h>
+#include <kernwin.hpp>
 
-//AsciiתUTF8
+//Ascii转UTF8
 std::string LocalCpToUtf8(const char* str);
 
+// 注意: IDA 9.4 原生 UTF-8, 源码/执行字符集均为 UTF-8, 字面量无需再转换。
+// 此函数仅保留兼容旧调用点, 现为直通实现; 运行期 GBK 数据请用 acp_utf8。
+inline qstring getUTF8String(const char* str)
+{
+	return qstring(str);
+}

--- a/E-Decompiler/Utils/md5.cpp
+++ b/E-Decompiler/Utils/md5.cpp
@@ -1,4 +1,4 @@
-#include "md5.h"
+﻿#include "md5.h"
 
 typedef unsigned int MD5_u32plus;
 typedef struct {

--- a/E-Decompiler/Utils/md5.h
+++ b/E-Decompiler/Utils/md5.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <string>
 
 std::string md5sum(const void* dat, size_t len);

--- a/E-Decompiler/resource.h
+++ b/E-Decompiler/resource.h
@@ -1,8 +1,8 @@
-//{{NO_DEPENDENCIES}}
+О╩©//{{NO_DEPENDENCIES}}
 // Microsoft Visual C++ generated include file.
 // Used by E-Decompiler.rc
 
-// пб╤тоС╣добр╩вИд╛хож╣
+// Ф√╟Е╞╧Х╠║Г └Д╦▀Д╦─Г╩└И╩≤Х╝╓Е─╪
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS

--- a/IDA9.4-PORT.md
+++ b/IDA9.4-PORT.md
@@ -1,0 +1,82 @@
+# IDA 9.4 迁移说明 (7.5 → 9.4)
+
+> 本分支将 E-Decompiler 插件从 IDA 7.5 迁移到 IDA 9.4。
+> 迁移过程中的关键发现记录如下, 供后续维护参考。
+
+## 构建环境
+
+| 组件 | 说明 |
+|---|---|
+| IDA SDK 9.4 | GitHub: [HexRaysSA/ida-sdk](https://github.com/HexRaysSA/ida-sdk) (已开源, MIT) |
+| 编译器 | MSVC v143 (VS2022 BuildTools 即可) |
+| Windows SDK | 10.0.26100.0 (其他 10.x 亦可) |
+| Qt | **无需安装** (见下文 Qt 部分) |
+
+## 构建方式
+
+旧 VS2019 vcxproj + Qt VsTools 工程已废弃, 改用 SDK 自带 CMake:
+
+```powershell
+cd E-Decompiler
+cmake -S . -B build          # IDASDK 缓存变量指向 SDK 根目录 (含 src/ 的 git 形态)
+cmake --build build --config Release
+```
+
+产物自动输出为 `E-Decompiler.dll`, 复制到 `<IDA>\plugins\` 即可。
+
+## 主要 API 变化 (7.5 → 9.4)
+
+| 变化 | 处理 |
+|---|---|
+| `bin_search2` 删除 | 改为 `bin_search(start, end, compiled_binpat_vec_t&, flags)`, 共 4 处 |
+| 旧 structs API 删除 (`add_struc`/`get_struc`/`add_struc_member`) | 虚表结构改用 til/udt API: `udt_type_data_t` + `udm_t` + `set_named_type(NTF_TYPE)` + `set_vftable()` |
+| `enumerate_files2` → `enumerate_files` | 新签名带 answer 缓冲参数 |
+| `plugin_t` / `action_desc_t` / `parse_decls` | **未变**, 零改动 |
+| `hexdsp_t` / Hex-Rays 插件机制 | 不变, 仍为 `init_hexrays_plugin()` 路线 |
+
+## HEXRAYS_API_MAGIC 版本匹配 (重要!)
+
+`init_hexrays_plugin()` 通过 `callui(ui_broadcast, HEXRAYS_API_MAGIC, ...)`
+与 hexrays 引擎握手, **魔数尾数即 hexrays API 版本**:
+
+- IDA 9.4.0 正式版引擎 (2026-07 之后): `0x00DEC0DE00000005`
+- 更早的 9.4 build (如 260610, 2026-06-10): `0x00DEC0DE00000004`
+
+**用 SDK 头文件编译的插件, 魔数必须与装机引擎匹配, 否则握手被拒、
+插件初始化失败** (出厂插件不受影响, 因其与引擎配套编译)。
+
+本仓库 `E-Decompiler/CMakeLists.txt` 通过 `EDEC_HEXRAYS_API_VERSION` 变量
+注入魔数, 默认 5 (匹配 9.4.0 正式版); 引擎较旧时传 `-DEDEC_HEXRAYS_API_VERSION=4`。
+
+> 选 SDK 头文件/魔数以装机引擎的构建日期为准, 不要盲目用 GitHub 最新。
+
+## 中文编码 (重要!)
+
+SDK 强制 `/utf-8` (源码与执行字符集均为 UTF-8), 而旧代码假定执行字符集为
+GBK (9.4 原生 UTF-8, **不再需要 7.5 时代的中文函数名补丁**)。因此:
+
+1. 全部源码由 GBK 转为 UTF-8 (BOM)
+2. 编码策略统一为 **"解析层一次转换, 存储/显示全 UTF-8 直通"**:
+   - 二进制/特征库中的 GBK 名称在解析时用 `acp_utf8` 转换 (ESymbol.cpp)
+   - 字面量本身已是 UTF-8, 不再经 `LocalCpToUtf8/getUTF8String` 二次转换
+   - `IDAWrapper::setFuncName` 去除 acp_utf8 (输入已为 UTF-8)
+3. 混淆案例: 事件名 = 控件名(GBK) + 事件字面量(UTF-8) 拼接后再按 GBK
+   整体转换 → 必然乱码。统一存储编码后自然消失。
+
+## Qt 模块
+
+ControlInfoWidget / PropertyDelegate 为独立 Qt 属性查看窗口, 与其余模块
+零耦合。9.4 已改用 Qt6, 若需启用请安装 Qt6 并以 `TYPE QT` 构建; 本迁移
+暂将其排除出构建, 核心分析功能不受影响。
+
+## 其他修复
+
+- `common/public.h` 缺失: `UCharToStr` 已在 Utils/Common.h, `getUTF8String` 移入 Utils/Strings.h
+- 源码统一转 UTF-8 BOM (SDK /utf-8 下 GBK 源码会触发 C2001)
+- ECSigParser::GetFunctionMD5 未声明变量补全 (历史遗留)
+
+## 验证
+
+以易语言 5.95 静态编译样本实测: 插件加载、库函数特征码识别 (中文名)、
+控件/事件解析与命名 (43 事件全中正常)、krnln 跳转表、虚表命名、
+Hex-Rays 反编译修正钩子均正常工作。


### PR DESCRIPTION
## 简介

把插件迁移到了 IDA 9.4, 已在易语言静态编译样本上验证可用。主要变更:

### 构建
- 弃用 VS2019 + Qt5.6 工程, 改用 SDK 自带 CMake (idasdk), MSVC v143 一键构建
- ControlInfoWidget/PropertyDelegate (Qt) 与核心无耦合, 暂排除出构建 (9.4 已是 Qt6)

### API 适配
- `bin_search2` 删除 → `bin_search` (4 处)
- 旧 structs API 建虚表结构 → til/udt API 重写 (`udt_type_data_t` + `set_vftable` + `set_named_type`)
- `enumerate_files2` → `enumerate_files`
- `plugin_t` / `action_desc_t` / `parse_decls` 未变

### HEXRAYS_API_MAGIC 版本问题 (重点)
`init_hexrays_plugin()` 的握手魔数尾数是 hexrays API 版本, 随引擎构建日期变化:
- IDA 9.4.0 正式版引擎 (2026-07 之后) = 5
- 更早的 9.4 build (如 260610) = 4

版本不匹配时握手直接被引擎拒绝, 插件无法初始化。
已在插件内做成可配置 `EDEC_HEXRAYS_API_VERSION` (默认 5, 旧引擎传 4), 并附反汇编对照。

### 中文编码
SDK 强制 `/utf-8` (源码+执行字符集均 UTF-8), 旧代码假定执行字符集为 GBK, 导致菜单/事件名双重编码乱码。
处理: 源码统一 GBK→UTF-8 (BOM); 编码策略统一为 "解析层一次转换, 存储/显示全 UTF-8 直通";
`setFuncName` 去除冗余转换。9.4 原生 UTF-8, 不再需要中文名补丁。

### 其他
- 源码全部 GBK→UTF-8 (BOM)
- `common/public.h` 缺失的两个辅助函数补进 Utils
- 新增 `IDA9.4-PORT.md` 迁移技术文档 (含详细排查记录)

已在多个易语言静态编译样本上验证: 库函数特征码识别、控件/事件解析命名、krnln 跳转表、
虚表命名、反编译修正钩子均正常工作。
